### PR TITLE
POC on exporting Jupyter notebooks to Markdown

### DIFF
--- a/dataframes/to-markdown.ipynb
+++ b/dataframes/to-markdown.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "045860fb-c575-4f35-b532-c58b5a4df323",
+   "metadata": {},
+   "source": [
+    "# To Markdown Demo\n",
+    "\n",
+    "This is a little demo notebook that'll be converted to markdown.  Let's see how it goes!\n",
+    "\n",
+    "Let's start by adding 2 and 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fa2bd3f9-5187-4739-b9e1-b3c5829a4ae8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "2 + 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "857e8494-1149-4db6-a60b-44d00d74be49",
+   "metadata": {},
+   "source": [
+    "This has a lot of potential... we'll see!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:standard-coiled] *",
+   "language": "python",
+   "name": "conda-env-standard-coiled-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/envs/standard-coiled.yml
+++ b/envs/standard-coiled.yml
@@ -19,3 +19,5 @@ dependencies:
   - jupyterlab_code_formatter
   - isort
   - black
+  - nbconvert
+  - pandoc


### PR DESCRIPTION
Here's a command to export a notebook as a Markdown file: `jupyter nbconvert --to markdown dataframes/to-markdown.ipynb`.

Probably won't end up merging this PR.