### PR TITLE
Add back NB corresponding to dataframe apply/map blog

### DIFF
--- a/blogs/parallelize-pandas-apply-and-map-with-dask-dataframe.ipynb
+++ b/blogs/parallelize-pandas-apply-and-map-with-dask-dataframe.ipynb
@@ -1,0 +1,892 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "id": "4534fef7-a4c3-4de5-88af-842033ce9b0a",
+            "metadata": {},
+            "source": [
+                "# Parallelizing pandas map() and apply() with Dask DataFrame"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "08842cb4-5c0e-4cfa-8c16-b53323c813c8",
+            "metadata": {},
+            "source": [
+                "Imports:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "id": "2b431640-4eb7-4327-9614-942e3d057dac",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import numpy as np\n",
+                "import pandas as pd\n",
+                "import dask.dataframe as dd\n",
+                "\n",
+                "from time import sleep"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "1bd609d8-0521-422e-bc36-df6919f31d95",
+            "metadata": {},
+            "source": [
+                "Create data:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "id": "2168d532-4e9a-4b06-9261-95824a825933",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "d = {\n",
+                "    'a': np.random.randint(20, size=10),\n",
+                "    'b': np.random.randint(20, size=10),\n",
+                "}"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "d708c1f2-99f6-4a18-864d-387f00c48cc1",
+            "metadata": {},
+            "source": [
+                "Define functions:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "id": "f573a78c-25b3-4b2f-9531-9eafc6e28c36",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "def minmax(x):\n",
+                "    sleep(1)\n",
+                "    return x.max() - x.min()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "id": "719d6f04-8818-492b-b342-46cc2c0e196a",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "def inc(i):\n",
+                "    sleep(1)\n",
+                "    return i+1"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "ecdabbc4-e6cf-487c-8352-3f0ff7de6444",
+            "metadata": {},
+            "source": [
+                "## pandas"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "id": "630ec884-d0e5-4f49-9060-3b8f9a00a85d",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "<style scoped>\n",
+                            "    .dataframe tbody tr th:only-of-type {\n",
+                            "        vertical-align: middle;\n",
+                            "    }\n",
+                            "\n",
+                            "    .dataframe tbody tr th {\n",
+                            "        vertical-align: top;\n",
+                            "    }\n",
+                            "\n",
+                            "    .dataframe thead th {\n",
+                            "        text-align: right;\n",
+                            "    }\n",
+                            "</style>\n",
+                            "<table border=\"1\" class=\"dataframe\">\n",
+                            "  <thead>\n",
+                            "    <tr style=\"text-align: right;\">\n",
+                            "      <th></th>\n",
+                            "      <th>a</th>\n",
+                            "      <th>b</th>\n",
+                            "    </tr>\n",
+                            "  </thead>\n",
+                            "  <tbody>\n",
+                            "    <tr>\n",
+                            "      <th>0</th>\n",
+                            "      <td>4</td>\n",
+                            "      <td>8</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>1</th>\n",
+                            "      <td>12</td>\n",
+                            "      <td>16</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>2</th>\n",
+                            "      <td>18</td>\n",
+                            "      <td>10</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>3</th>\n",
+                            "      <td>2</td>\n",
+                            "      <td>10</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>4</th>\n",
+                            "      <td>15</td>\n",
+                            "      <td>4</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>5</th>\n",
+                            "      <td>16</td>\n",
+                            "      <td>12</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>6</th>\n",
+                            "      <td>17</td>\n",
+                            "      <td>11</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>7</th>\n",
+                            "      <td>16</td>\n",
+                            "      <td>16</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>8</th>\n",
+                            "      <td>16</td>\n",
+                            "      <td>6</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>9</th>\n",
+                            "      <td>4</td>\n",
+                            "      <td>2</td>\n",
+                            "    </tr>\n",
+                            "  </tbody>\n",
+                            "</table>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "    a   b\n",
+                            "0   4   8\n",
+                            "1  12  16\n",
+                            "2  18  10\n",
+                            "3   2  10\n",
+                            "4  15   4\n",
+                            "5  16  12\n",
+                            "6  17  11\n",
+                            "7  16  16\n",
+                            "8  16   6\n",
+                            "9   4   2"
+                        ]
+                    },
+                    "execution_count": 5,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "df = pd.DataFrame(d)\n",
+                "df"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "id": "3b3bddd1-256b-4289-9222-5e003816b775",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "CPU times: user 8.18 ms, sys: 1.37 ms, total: 9.55 ms\n",
+                        "Wall time: 10 s\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/plain": [
+                            "0     4\n",
+                            "1     4\n",
+                            "2     8\n",
+                            "3     8\n",
+                            "4    11\n",
+                            "5     4\n",
+                            "6     6\n",
+                            "7     0\n",
+                            "8    10\n",
+                            "9     2\n",
+                            "dtype: int64"
+                        ]
+                    },
+                    "execution_count": 6,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "%%time\n",
+                "df.apply(minmax, axis=1)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "id": "fb7e2d7a-8ae5-43f9-8018-8d65b4056829",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "CPU times: user 2.71 ms, sys: 1.64 ms, total: 4.36 ms\n",
+                        "Wall time: 10 s\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/plain": [
+                            "0     5\n",
+                            "1    13\n",
+                            "2    19\n",
+                            "3     3\n",
+                            "4    16\n",
+                            "5    17\n",
+                            "6    18\n",
+                            "7    17\n",
+                            "8    17\n",
+                            "9     5\n",
+                            "Name: a, dtype: int64"
+                        ]
+                    },
+                    "execution_count": 7,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "%%time\n",
+                "df.a.map(inc)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "id": "7f67e449-421e-4460-8a05-6c8f30f2bc33",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "CPU times: user 5 ms, sys: 2.2 ms, total: 7.2 ms\n",
+                        "Wall time: 20.1 s\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "<style scoped>\n",
+                            "    .dataframe tbody tr th:only-of-type {\n",
+                            "        vertical-align: middle;\n",
+                            "    }\n",
+                            "\n",
+                            "    .dataframe tbody tr th {\n",
+                            "        vertical-align: top;\n",
+                            "    }\n",
+                            "\n",
+                            "    .dataframe thead th {\n",
+                            "        text-align: right;\n",
+                            "    }\n",
+                            "</style>\n",
+                            "<table border=\"1\" class=\"dataframe\">\n",
+                            "  <thead>\n",
+                            "    <tr style=\"text-align: right;\">\n",
+                            "      <th></th>\n",
+                            "      <th>a</th>\n",
+                            "      <th>b</th>\n",
+                            "    </tr>\n",
+                            "  </thead>\n",
+                            "  <tbody>\n",
+                            "    <tr>\n",
+                            "      <th>0</th>\n",
+                            "      <td>5</td>\n",
+                            "      <td>9</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>1</th>\n",
+                            "      <td>13</td>\n",
+                            "      <td>17</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>2</th>\n",
+                            "      <td>19</td>\n",
+                            "      <td>11</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>3</th>\n",
+                            "      <td>3</td>\n",
+                            "      <td>11</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>4</th>\n",
+                            "      <td>16</td>\n",
+                            "      <td>5</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>5</th>\n",
+                            "      <td>17</td>\n",
+                            "      <td>13</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>6</th>\n",
+                            "      <td>18</td>\n",
+                            "      <td>12</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>7</th>\n",
+                            "      <td>17</td>\n",
+                            "      <td>17</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>8</th>\n",
+                            "      <td>17</td>\n",
+                            "      <td>7</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>9</th>\n",
+                            "      <td>5</td>\n",
+                            "      <td>3</td>\n",
+                            "    </tr>\n",
+                            "  </tbody>\n",
+                            "</table>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "    a   b\n",
+                            "0   5   9\n",
+                            "1  13  17\n",
+                            "2  19  11\n",
+                            "3   3  11\n",
+                            "4  16   5\n",
+                            "5  17  13\n",
+                            "6  18  12\n",
+                            "7  17  17\n",
+                            "8  17   7\n",
+                            "9   5   3"
+                        ]
+                    },
+                    "execution_count": 8,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "%%time\n",
+                "df.applymap(inc)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "df5c2229-8408-4cd3-91bb-ab7551b84fd3",
+            "metadata": {},
+            "source": [
+                "## Dask"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 9,
+            "id": "694c2738-9945-4230-b15f-707d6cd89af5",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import dask.dataframe as dd"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 10,
+            "id": "4eb6e430-46ba-4af4-8dfe-62697a517b7a",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "ddf = dd.from_pandas(df, npartitions=5)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 11,
+            "id": "3f31a76e-9e29-4195-8f90-dfa56fe8dbe5",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/html": [
+                            "<div><strong>Dask DataFrame Structure:</strong></div>\n",
+                            "<div>\n",
+                            "<style scoped>\n",
+                            "    .dataframe tbody tr th:only-of-type {\n",
+                            "        vertical-align: middle;\n",
+                            "    }\n",
+                            "\n",
+                            "    .dataframe tbody tr th {\n",
+                            "        vertical-align: top;\n",
+                            "    }\n",
+                            "\n",
+                            "    .dataframe thead th {\n",
+                            "        text-align: right;\n",
+                            "    }\n",
+                            "</style>\n",
+                            "<table border=\"1\" class=\"dataframe\">\n",
+                            "  <thead>\n",
+                            "    <tr style=\"text-align: right;\">\n",
+                            "      <th></th>\n",
+                            "      <th>a</th>\n",
+                            "      <th>b</th>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>npartitions=5</th>\n",
+                            "      <th></th>\n",
+                            "      <th></th>\n",
+                            "    </tr>\n",
+                            "  </thead>\n",
+                            "  <tbody>\n",
+                            "    <tr>\n",
+                            "      <th>0</th>\n",
+                            "      <td>int64</td>\n",
+                            "      <td>int64</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>2</th>\n",
+                            "      <td>...</td>\n",
+                            "      <td>...</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>...</th>\n",
+                            "      <td>...</td>\n",
+                            "      <td>...</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>8</th>\n",
+                            "      <td>...</td>\n",
+                            "      <td>...</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>9</th>\n",
+                            "      <td>...</td>\n",
+                            "      <td>...</td>\n",
+                            "    </tr>\n",
+                            "  </tbody>\n",
+                            "</table>\n",
+                            "</div>\n",
+                            "<div>Dask Name: from_pandas, 5 tasks</div>"
+                        ],
+                        "text/plain": [
+                            "Dask DataFrame Structure:\n",
+                            "                   a      b\n",
+                            "npartitions=5              \n",
+                            "0              int64  int64\n",
+                            "2                ...    ...\n",
+                            "...              ...    ...\n",
+                            "8                ...    ...\n",
+                            "9                ...    ...\n",
+                            "Dask Name: from_pandas, 5 tasks"
+                        ]
+                    },
+                    "execution_count": 11,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "ddf"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 12,
+            "id": "aeaa5479-020f-4a00-98cc-ec19d411e1ad",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "def minmax2(df):\n",
+                "    return df.apply(minmax, axis=1)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 13,
+            "id": "922ed132-2d02-4e08-b52c-a3ff3f5cc9bf",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "CPU times: user 10.1 ms, sys: 2.23 ms, total: 12.3 ms\n",
+                        "Wall time: 2.02 s\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/plain": [
+                            "0     4\n",
+                            "1     4\n",
+                            "2     8\n",
+                            "3     8\n",
+                            "4    11\n",
+                            "5     4\n",
+                            "6     6\n",
+                            "7     0\n",
+                            "8    10\n",
+                            "9     2\n",
+                            "dtype: int64"
+                        ]
+                    },
+                    "execution_count": 13,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "%%time\n",
+                "p = ddf.map_partitions(minmax2, meta=(None, 'int64'))\n",
+                "p.compute()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 14,
+            "id": "91ebf884-6a49-44a8-85fa-8c4015b7ebb8",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAuQAAAFJCAYAAADTzjjIAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdeVyU5foG8GuGYXNhNUEUATdwATUtEzT3hTLLvUzTLM1KLeu0109PndPuycqOS+XRIg2XzH3BSkU0TVFxSUEBRXHFFQQZZu7fHx44qYgs884zy/X9fPwjlnku4Om97tneVyciAiIiIiIiUiFNrzoBEREREZEz40BORERERKQQB3IiIiIiIoUMKhcvLCzEzz//rDKCXejcuTNq166tOoZdSU9Px44dO1THsGnu7u54+OGHVcewOxs3bsTp06dVx7BpDRs2RJs2bVTHsCvsw/JhH1Yc+/DObKEPdSrf1JmTk4NatWqpWt5urF+/Ht26dVMdw67MmDEDzz77rOoYNs3X1xfnz59XHcPudO3aFb/99pvqGDbtmWeewYwZM1THsCvsw/JhH1Yc+/DObKAPbeNNnevXr4eI8N9N/86dO6f6T2PXfH19lf8NbfXf9OnTVf957Nozzzyj/G9oq/+6dOmi+s9j19iHpf9jH1YN+/D2/2ylD21iICciIiIiclYcyImIiIiIFOJATkRERESkEAdyIiIiIiKFOJATERERESnEgZyIiIiISCEO5ERERERECnEgJyIiIiJSiAM5EREREZFCHMiJiIiIiBTiQE5EREREpBAHciIiIiIihTiQExEREREpxIH8JmazWXUEIqIKyc3NVR2BHExRURFMJpPqGOTArly5gpycHNUxbAYHcgCpqal44YUXEBoaCn9/f/Tp0we//PKL6ljkYBo3bozRo0erjkEOIjk5Gb169YKfnx9q1qyJwMBAPPPMM7h8+bLqaGTHfvjhB0RHR6NmzZrw8PBAREQEpk2bxgeryKJycnIQERGBjh07qo5iM5x+IM/Pz0ffvn0xe/Zs9OrVC88++yzS0tLw0EMPYdOmTarjkYOYM2cODh8+rDoGOYgdO3aga9eu2LlzJ4YOHYp33nkH3t7emDVrFrp3787hiSrlu+++w/Dhw3HhwgW88MILeO6555Cbm4vx48fj/fffVx2PHMhTTz2F7Oxs1TFsikF1ANXeeustHDp0CKtWrUJsbCwA4IUXXkDLli0xcuRIpKenK05I9ur48eP4+9//jj/++AN79uxRHYccyLRp05Cfn49t27ahVatWAIB3330X3bt3xy+//ILFixdj0KBBilOSvZkyZQoaN26Mbdu2wcvLCwDw2muvISwsDF999RXefvttxQnJEUyfPh1r1qyBn5+f6ig2xekfIZ8zZw6ioqJKhnEACAgIQK9evZCRkYFt27YpTEf27MqVK0hNTYW3tzfuuece1XHIgWzZsgWtWrUqGcaLPfnkkwCA7du3q4hFduzSpUvYt28fYmNjS4ZxAAgKCkLXrl1x/vx5GI1GhQnJEezfvx8vv/wyPvroI9SpU0d1HJvi1I+Qnzt3DhcuXCgpsb9q0qQJgOtPDbdr187a0cgBNG3aFBs3bgQAHD58GI0bN1aciByB0WhEr169cO+9997yuaysLADgI09UYQaDAZs2bUKDBg1u+PilS5eQkpKCnj17wtXVVVE6cgQFBQV47LHH0LFjR0yYMAFff/216kg2xakH8kOHDgFAqffSwsPDAQBnzpyxaiYiorK4urriyy+/vOXjZ86cwVdffQVXV1f06dNHQTKyZ9WrV0dMTEzJf0+dOhVHjx7FypUrYTKZ8MYbbyhMR47glVdeQXZ2NtauXQudTqc6js1x6oG8+E12pT2aFBISAgC4ePGiVTMREVXUihUr8NRTT+Hs2bOYOnUqIiMjVUciO/fWW2/h6tWrAIDmzZvD09NTcSKyZytWrMC0adPw008/8aUqt+HUryF3d3cHAJw/f/6Wz+Xl5QEAfH19rZqJiKi8jhw5gr59++Khhx6Cl5cX1q1bhwkTJqiORQ4gLy8PqampmD17NnJyctCuXTucOnVKdSyyQydPnsSTTz6Jp59+Gv369VMdx2Y59SPkgYGBAFDqmVSKh/S77rrLqpmIiMojLi4Ozz77LHQ6HT7++GNMmDCh5EEGoooSEYgI9Pr/PU7XuHFjNG7cGHq9HiNHjsSqVaswatQohSnJHk2fPh3nzp3DpUuXbnjP3okTJyAiePLJJ9GkSROnf1mUUw/kTZo0gU6nK3UgLz5NHd/QSUS2ZsWKFXjiiSfQvn17zJ8/H/Xr11cdiezchx9+iDfffBMrV67EAw88cMPnatWqBeB/bxomqoi77roLrVq1Qlpa2g0fv3btGsxmM3bv3n3DHUFn5dQDeVBQEO6//35s2rQJR44cQcOGDQFcP4vBvHnzULduXbRp00ZxSiKiG7355pvw9vbGokWL+HpMsoji9x0kJCTcMpAXnw2jZcuWVs9F9m/8+PEYP378LR9v06YN8vPzsWvXLgWpbI9TD+TA9WJ78MEHMXjwYLz11lvw9fXFRx99hPT0dKxYsYLvBCYim3LhwgXs27cPrVu3xpQpU0r9ms6dO/NMK1QhDzzwACIjI/Hll1/Cx8cHvXr1wokTJ7Bw4UIsX74c99xzD/cUkYacfiDv2bMnvv/+ezz99NMYMGAAAMDHxwf/+te/brhYEBGRLUhKSoKIIDk5GcnJyaV+jU6n4/BEFaLX6/Hzzz9j2LBhmDx5MiZPnlzyuf79++OLL76AweD0IwORZvh/F4BHH30UAwcOxI4dO2A2m9GuXTu4uLiojkUOpFGjRhAR1THIAfTp04d7iTTRoEEDbN68GRkZGTh48CA8PT0RHh6OunXrqo5GDmjnzp2qI9gUDuT/ZTAYcN9996mOQUREpIxer0fDhg1L3lNFRNbBt7USERERESnEgZyIiIiISCEO5ERERERECnEgJyIiIiJSiAM5EREREZFCHMiJiIiIiBTiQE5EREREpBAHciIiIiIihTiQExEREREpxIGciIiIiEghDuRERERERApxICciIiIiUogDORERERGRQhzIiYiIiIgU4kBORERERKQQB/KbXLlyRXUEclDcW6SF3NxciIjqGOSAeMwirXBv3cqgOgAAbNy4ETk5OapjAABmzJiBMWPGQK9Xf18lNzdXdQS7VlhYiAULFqiOAQDIy8vDkiVLMGzYMNVRAAA7d+5UHcGupaen28ze+u2331CnTh1ERESojgIAOHPmDJo0aaI6ht1iH5aOfVg17MPbs5U+tImB/L333lMd4Qa//fab6ghkAXl5eRgyZIjqGDdYvny56gglfH19VUewWwkJCUhISFAdw2Z16NBBdQS7xT4kLbAPy2YLfagTPtdZ4t///jeef/55jB49GrNmzVIdhxxIx44dsXnzZqxbtw49evRQHYccxKlTp1C3bl14eXnhzJkzcHV1VR2JHAT7kLTCPixVmvrnoWzI999/DwCIj49HYWGh4jTkKLKzs5GUlASdTod58+apjkMOZMGCBdDpdLh48SJ++eUX1XHIgbAPSQvsw9vjQP5fWVlZ2LZtG4DrbzZYu3at4kTkKObPnw8XFxeICBYsWID8/HzVkchBzJ07FyICV1dXlhtZDPuQtMI+vD0O5P81b948uLi4AABcXFzwww8/KE5EjuK7776DyWQCAOTn52PNmjWKE5EjSE9Px65du2A2m2E0GrFo0SKWG1kE+5C0wj68PQ7k//XXTVJUVISff/6Z7+qmKjt8+DBSUlJKTkvn4uKCuLg4xanIEcybNw8Gw//el19QUIAVK1YoTESOgn1IWmAflo0DOYCDBw/iwIEDN5zL12g0YtmyZQpTkSOIi4u74Y12RUVFWL58OS5duqQwFTmC77//HkajseS/WW5kCexD0gr7sGwcyAH88MMPt5ydQKfTlbyphaiy4uLibhiaAMBkMmHp0qWKEpEj2LNnD1JTU2/4WFFREVavXo2LFy8qSkWOgH1IWmEflo0DOW59pAm4vkkSEhJs5gINZH927tyJI0eOlPo5lhtVxfz580s9xaHZbMZPP/2kIBE5CvYhaYF9eGdOP5Bv27YNR48eve3nFy9ebMU05Ejmz58PNze3Wz5uNpvx22+/4fTp0wpSkb0TkVKHpmIsN6os9iFphX14Z04/kN9ukwDXi++7776zciJyBGazGXFxcWWev3fRokVWTESOYsuWLcjOzi71cyaTCRs3brzt54nKwj4kLbAPy8epB3Kz2Yx58+bddpOYzWZs2bIFx48ft3IysneJiYll3uM3m80sN6qU271cpZiLiwvLjSqMfUhaYR+Wj1MP5L/99hvOnj1b5tcYDAbEx8dbKRE5irIeaQKuP9r0xx9/IDMz03qhyO4VFRVh/vz5t325CnD9UXKWG1UU+5C0wj4sH6ceyOfPnw+dTlfm1xiNRpYbVYjRaMT8+fPveLlpEcGPP/5opVTkCH755RecP3++zK8RESQnJ9/2DVREpWEfkhbYh+VnuPOXOC4XFxcMHDiw5L+NRiMSEhLQrl07+Pv73/C1Fy9ehI+Pj7Ujkh06cuQIevXqdcPHjh07htTUVHTv3v2Gj/PKilQR2dnZGDRo0A0f27ZtG6pXr44WLVrc8PG0tDQ0bNjQmvHIjrEPSQvsw/LTyV/P/u/kcnJyUKtWLaxfvx7dunVTHYccyIwZM/DWW2/xtGFkcd26dUOTJk0wffp01VHIgbAPSSvsw1KlOfVLVoiIiIiIVONATkRERESkEAdyIiIiIiKFOJATERERESnEgZyIiIiISCEO5ERERERECnEgJyIiIiJSiAM5EREREZFCHMiJiIiIiBTiQE5EREREpBAHciIiIiIihTiQExEREREpxIGciIiIiEghDuRERERERApxICciIiIiUogDORERERGRQhzIiYiIiIgU4kBORERERKQQB3IiIiIiIoU4kBMRERERKcSBnIiIiIhIIQ7kREREREQKcSAnIiIiIlKIAzkRERERkUIcyImIiIiIFOJATkRERESkEAdyIiIiIiKFOJATERERESnEgZyIiIiISCEO5ERERERECnEgJyIiIiJSyKA6gEp5eXnIyclBTk4OzGYzTp06BQBISUmBj48PAMDPzw/+/v7w8vJSGZXszPnz55GTk4PLly8DAA4dOgSj0YgtW7bA3d0drq6u8Pf3h7+/Pzw8PBSnJXthNBpLjlkFBQUoKirC+fPncfz4cezYsQM6nQ7Vq1cv2Vt6PR9zofJhH5JW2IfloxMRUR1CSydOnMDevXuxZ88epKWlITMzE5mZmThx4gQKCgrKfTuurq4IDAxEaGgowsLC0KhRI7Ro0QJRUVFo0KABdDqdhj8F2ZqioiKkpqZi7969SElJQUZGRsneOnPmDEwmU7lvq3r16ggODkZoaChCQ0MRERGByMhItGzZEv7+/hr+FGSLrly5gn379iElJQUHDhwo2VtZWVm4ePFihW6rdu3aJXsrLCwMzZs3R1RUFJo1a+bUxees2IekBfahRaQ51EBuMpnwxx9/YPPmzUhKSsKWLVtw5swZAEC9evUQERFR8kcODg4uuUdWq1Yt6PV6eHp6wsPDA0ajEbm5uQCu37M7d+4ccnJykJ2dXbLJDh06hIyMDJjNZnh5eeG+++5DdHQ0OnbsiJiYGLi7u6v8VZCFXblyBRs2bCjZVzt27EB+fj4MBgOaNGmCRo0alZRTQEAA7rrrLtSqVavkkSRvb2/o9Xrk5eWhsLCw5JHOc+fO4dy5czh27FjJQezAgQM4d+4cAKB+/fro0KED2rdvj86dO6NFixYqfw2kgYyMjBv21sGDByEi8PLyQrNmzRAWFobQ0FDUr18fAQEBqFWrVskjSS4uLiV77OLFixCRkkc6z507h1OnTuHo0aPIzMxEeno6Dhw4gIKCAhgMBkRFRSEmJgbR0dHo2rUrateurfg3QZbEPiStsA81Yf8D+eXLl7Fs2TKsXLkSCQkJyMnJQWBgINq3b48OHTrg7rvvRlRUFPz8/Cy+dm5uLvbv34/k5GRs2bIFSUlJyMjIQPXq1dGlSxfExsaiX79+qFOnjsXXJu0dPnwYP/30E1avXo2kpCSYTCY0bdoU0dHRiI6ORsuWLdG8eXO4ublZfO2TJ09i79692L59O7Zs2YKtW7fi4sWLqFevHnr37o0+ffqgV69efJTTDplMJiQmJmLp0qVYs2YNDh48iGrVqqFt27aIiYlBu3btEBUVhdDQUIs/0mgymZCWloY9e/Zg69at2LJlC3bt2gWz2Yy7774bvXv3xiOPPII2bdpYdF2yDvYhaYV9qDn7HMivXbuGpUuXYt68eVi7di3MZjM6deqE3r17IzY2Fk2bNlWWLSsrC2vWrMHq1auxfv165OXl4f7778ejjz6KRx99FN7e3sqy0Z2dOnUK33//PeLj47Fz507cddddJfuqR48eqFWrlpJcZrMZO3fuxJo1a7Bq1Sps374dNWrUwMMPP4yhQ4eiZ8+efL2wjdu+fTu+//57LFq0CKdOnUKLFi0QGxuL2NhYxMTEaFJk5ZGXl4dff/0Vq1evxurVq5GZmYlGjRph8ODBeOKJJxAeHq4kF5UP+5C0wj60qjSIHUlNTZWXX35ZatWqJQaDQWJjY2X27Nly/vx51dFKdfXqVVm8eLEMGTJEqlWrJtWqVZORI0fK77//rjoa/YXZbJbVq1dLv379xNXVVfz8/GT06NGSkJAgRUVFquOV6sSJE/L5559LdHS06HQ6CQkJkXfffVeys7NVR6O/uHz5skybNk1atmwpAKR58+by7rvvysGDB1VHu63t27fL3/72N6lfv77odDrp1KmTxMXFybVr11RHo79gH5IW2IfKpNrFQJ6YmCiDBg0SFxcXqVu3rrz22muSmZmpOlaFXLp0SWbOnCl33323AJA2bdrI3LlzxWg0qo7mtK5duyZz586V5s2bl/xNZs6cKXl5eaqjVcihQ4fktddek9q1a4ubm5sMHz5cUlJSVMdyaidPnpRJkyaJn5+feHh4yKBBgyQhIUF1rAoxmUySkJAggwYNEldXVwkICJBJkybJuXPnVEdzauxD0gL7UDnbHsgTExOlS5cuDvc/7I4dO2T48OHi4uIiYWFhMnPmTJu95+mIrl27JjNnzpSgoCB7+x+2TDcfULt37y47d+5UHcupHDt2TCZMmCDu7u4lA2xOTo7qWFX21zsY1atXl9dee81mH4l1VOxD0gL70GbY5kC+Y8cO6dq1a8kvMSkpSXUkTRw8eFAef/xx0ev1EhkZKevWrVMdyaGZTCb59ttvJTg4WDw8POTFF1+UkydPqo5lcWazWZYtWyatW7cWvV4vjz76qBw7dkx1LIeWk5MjL7zwgri7u0tISIh88803DvkSj8uXL8v7778vfn5+4uPjIx9++KFD/py2hH1IWmAf2hzbGshPnjwpo0aNEr1eL9HR0bJx40bVkaxi//798sgjjwgAGTx4sBw/flx1JIezadMmadOmjRgMBhk7dqxT/I7NZrMsWrRImjRpItWrV5ePPvpICgsLVcdyKEajUb744gvx8/OTgIAA+eqrr5xiQL106ZJMmjRJqlWrJhEREfLLL7+ojuRw2IfsQ62wD22yD21jIDebzTJ37lzx8/OTunXryty5c8VsNquOZXW//PKLRERESLVq1WTSpElOUexau3DhgowZM0Z0Op1069ZN9uzZozqS1RUWFsrUqVOlRo0a0qRJEz7yZCG7d++Wtm3biqurq0yYMEEuXryoOpLVHT9+XIYPHy4ApE+fPrb6yJNdYR9exz60PPahTfeh+oH8yJEj0qlTJzEYDPLqq6/a3RsILC0/P18mTZokHh4eEhkZKVu3blUdyW4tWbJEAgMDpU6dOrJ48WLVcZRLT0+XPn36iE6nk2HDhvHNeZVUUFAgr7zyihgMBuncubOkpqaqjqTc8uXLJSwsTLy8vOSLL75wygHSEtiHN2IfWg778EY22IdqB/JFixaJt7e3REVF2fqL7a0uLS1NevbsKa6urvLxxx+z4CqgoKBAxo0bJwBk1KhRcuHCBdWRbMrPP/8swcHBUr9+fYd9PapWDh8+LG3atBEvLy+ZNWsW/7/8i6tXr8rbb78tBoNB+vTpYwsFZ1fYh7fHPqw89mHZbKgP1QzkBQUFMmHCBNHpdDJ8+HCnfxTgdsxms0ydOlXc3Nyke/fucurUKdWRbF5mZqbcd999UrNmTZk3b57qODbr4sWLMmDAADEYDDJp0iQxmUyqI9m8JUuWiK+vr7Ru3ZqPipdh+/btEhYWJvXq1ZPExETVcWwe+7B82IcVxz4sHxvpQ+sP5JmZmdKuXTtukApgwZXPTz/9JD4+PtK6dWtJS0tTHcfmseDKp3hgAsCBqZxspOBsHvuw4tiH5cM+rBgb6EPrDuSrV68WLy8vbpBKyMnJkYceekgMBoNMmzZNdRybYjKZZOLEiQJAnnvuOSkoKFAdya5s2bJF6tevL/Xq1XPKN/mU5eTJkyUvUYmPj1cdx66YzWb55JNPxNXVVfr27cs7MjdhH1Ye+/D22IdVo7APrTeQx8XFiaurqwwfPpwbpJLMZrO89957otPp5O2331YdxyZcu3ZNHnvsMXFzc5MffvhBdRy7lZOTI507dxYfHx+nOb3anRw+fFgaNGggjRs35sBUBZs3bxZ/f39p3769Q1wkyRLYh1XHPrwV+9AyFPWhdQbyL774QvR6vUyYMIFPXVrA3LlzxWAwyMiRIx3iSm2VlZubK7GxsVK9enVZs2aN6jh2r6CgQAYPHizu7u6yYMEC1XGU2rt3rwQFBUmbNm3k9OnTquPYvT///FPq168vTZs2laNHj6qOoxT70LLYh9exDy1LQR9qO5CbzWaZNGmS6HQ6mTRpkpZLOZ1ly5aJp6en9O3bV65evao6jtXl5ORIdHS0+Pv781RYFlRUVCRjx44VFxcXmTFjhuo4Svz222/i7e0tXbp0kUuXLqmO4zCys7OlZcuWEhQU5BCX5q4o9qF22IfsQy1YuQ+1G8jNZrOMGTNGDAaDzJ07V6tlnFpiYqL4+vpK586dneogdPLkSYmIiJCwsDCe7UIjxYPDJ598ojqKVS1fvlzc3d1lyJAhvBCJBs6fPy8xMTHi7+8vycnJquNYDftQe+xD9qFWrNSH2g3kr7/+uri6usrSpUu1WoJEZM+ePeLn5ycPPfSQUzxdd+nSJWndurU0btxYsrOzVcdxaJ999pnodDqZPXu26ihWkZiYKJ6enjJq1Ci+lEBDeXl50q1bNwkMDJTDhw+rjmMV7EPrYB+SVqzQh9oM5NOmTXOqIldt27ZtUr16dRk2bJhDXzDh2rVr0qNHDwkKCpL09HTVcZzCW2+9JS4uLg5/Zbd9+/aJn5+f9O3b1ymKXLXLly9LmzZtpEGDBnLy5EnVcTTFPrQu9iFpReM+tPxAPm/ePNHr9U73VLdqK1asEFdXV3n99ddVR9GEyWSSQYMGiZeXl+zatUt1HKdhNpvl6aefFk9PT9m0aZPqOJrIysqS4OBg6dSpk+Tn56uO4zTOnj0r4eHhEhkZ6bBXD2QfqsE+JC1o3IeWHcjXr18v7u7u8sorr1jyZqmc4uLiRKfTyZQpU1RHsbjx48eLh4cHT8mnQFFRkQwYMEC8vb1l9+7dquNY1NmzZyUiIkIiIyPl/PnzquM4nfT0dKlTp4507tzZ4e4MsQ/VYh+SFjTsQ8sN5GlpaeLl5SXDhw936KeJbN1HH30ker1e1q1bpzqKxUybNk1cXFxkyZIlqqM4ratXr0qHDh2kQYMGcvHiRdVxLKKoqEi6du0qYWFhfP2lQrt37xYvLy8ZO3as6igWwz60DexD0oJGfWiZgbygoEDuvvtuiYqKcqp3N9uqxx9/XGrXri0nTpxQHaXK9uzZI56enjJ58mTVUZze6dOnJSgoSAYOHKg6ikVMmjRJ3N3dZefOnaqjOL2FCxcKAImLi1MdpcrYh7aFfUha0KAPLTOQP//881KjRg05ePCgJW6OqujKlSsSEREhnTp1kqKiItVxKu3KlSsSHh4unTt3tuufw5Fs2LBBXFxc5KuvvlIdpUoc5edwJOPGjXOIHmEf2hb2IWnFwj1S9YHckR7ZcCQpKSni6elp1xegcKRHNhzJ5MmT7fqRZUd7pN9RFBQUSJs2bez6kWX2oW1iH5JWLNiHVRvIjxw5It7e3vLss89WNQhpYPr06eLi4iK//PKL6igVNn36dNHr9bJ+/XrVUegmJpNJunXrJo0aNbK7K1maTCbp3r27NGzY0GFeC+9IDh8+LN7e3vL888+rjlJh7EPbxj4kLViwDys/kJvNZunUqZNERUU53LvjHcnAgQMlNDRU8vLyVEcptyNHjki1atXk7bffVh2FbuPUqVNSu3ZtGTdunOooFfLFF1+Iq6ur7NixQ3UUuo34+HjR6XSyYcMG1VHKjX1oH9iHpAUL9WHlB/Lp06eLwWBgsdm4U6dOiY+Pj7z11luqo5SL2WyWHj16SGRkJC9dbuPmzJkjer1etm3bpjpKuRw9elRq1qzJYrMDffr0kWbNmklhYaHqKOXCPrQP7EPSigX6sHID+cmTJ8Xb25vnV7UTn3/+ubi7u9vFm4zmzJkjLi4u8vvvv6uOQndgNpulY8eO0q5dO7u41PyDDz4oERERUlBQoDoK3cGRI0fE09NTPv74Y9VR7oh9aF/Yh6QFC/Rh5QbyUaNGSf369e3qaR9nVlRUJK1atZLu3burjlKmy5cvS506deS5555THYXKKSUlRQwGg8yaNUt1lDKtWrVKAMivv/6qOgqV09///nepUaOGHDt2THWUMrEP7Qv7kLRSxT6s+ECenJwser1efvzxx8osSIps375d9Hq9xMfHq45yW6+//rr4+vrK2bNnVUehCpg4caL4+fnJmTNnVEcpldFolObNm8uAAQNUR6EKKCgokPDwcJs+Gw770D6xD0krVejDVJ2ICCqgW7duKCgowObNm6HT6SryraTYU089hYSEBKSlpcHd3V11nBscP34cjRs3xgcffIAXX3xRdfdP2w4AACAASURBVByqgCtXriAiIgL9+/fHl19+qTrOLWbMmIEXX3wRBw4cQIMGDVTHoQpYs2YNYmNjsWHDBnTq1El1nFuwD+0X+5C0UIU+TKvQI+SbNm0SAHb17nf6n+zsbPH09JQvvvhCdZRbjB07VurXr8/X99qpf//73+Lm5ibp6emqo9wgPz9f6tWrJ+PHj1cdhSqpa9euEhMTozrGLdiH9o19SFqpZB9W7BHyDh06oFq1ali3bl1F7zSQjZg4cSLi4+Nx5MgReHp6qo4DAMjMzER4eDimTZuG0aNHq45DlVBYWIjw8HD06NEDs2bNUh2nxOeff4433ngDR44cQZ06dVTHoUrYsmULYmJisG7dOvTo0UN1nBLsQ/vHPiQtVLIPy/8I+caNGwWAJCUlVfTOAtmQU6dOiaenp01dMvz555+XsLAwuznFGZXum2++ETc3Nzl+/LjqKCIiUlhYKPXq1ZOJEyeqjkJV1KtXL+ncubPqGCXYh46BfUhaqUQfpurLO7pPmTIFHTp0QHR0dGXuMJCNCAgIwIgRI/Dpp5/CZDKpjoMLFy5gzpw5ePHFF+Hq6qo6DlXBsGHD4O/vbzOvI//xxx9x6tQpvgbTAbzyyivYsGEDtm3bpjoKAPaho2AfklYq04flGsjT0tKwYsUKTJw4sdLhyHZMnDgRR48exdKlS1VHwYwZM+Dm5oZRo0apjkJV5O7ujnHjxmHmzJnIzc1VHQdTp07FoEGDUL9+fdVRqIq6deuG1q1bY+rUqaqjsA8dDPuQtFCZPizXQD5z5kzUr18fDz/8cJUCkm1o0qQJHnjgAcyYMUNpDrPZjFmzZmHUqFGoUaOG0ixkGWPHjkVBQQHmz5+vNMe2bduQnJyMF154QWkOspwXXngBP/30E86cOaM0B/vQsbAPSSsV7cM7DuSFhYX47rvv8NRTT8HFxaXKAck2PP3001i/fj2OHDmiLMPatWuRmZmJp556SlkGsiw/Pz/0798f3377rdIcs2bNQlRUFNq1a6c0B1nO4MGDUb16dXz33XfKMrAPHRP7kLRQ0T6840D+888/48KFC3jyySerHI5sx4MPPog6depgzpw5yjJ8++236NSpE5o2baosA1ne6NGjsW3bNuzdu1fJ+leuXEF8fDzPUOBgPD098dhjjym9s8c+dEzsQ9JKRfrwjgP5vHnz0L17d9StW9ci4cg2GAwGDB06FD/++KOS9S9fvoyVK1dixIgRStYn7XTq1AkhISHKXraybNkyFBYWYujQoUrWJ+2MGDECBw8exK5du5Sszz50TOxD0kpF+rDMgfzy5ctYu3YthgwZYrFwZDuGDBmCw4cPY+fOnVZf++eff4bJZOLrMB2QTqfD4MGDER8fD6nYhYAtIj4+Hj179oSfn5/V1yZt3XvvvWjYsCHi4+Otvjb70LGxD0kLFenDMgfyZcuWwWw2c5M4qLZt26JBgwZYsGCB1ddetGgRhyYHNnjwYKSnpyM5Odmq616+fBnr1q3DoEGDrLouWc/AgQOxcOFCq6/LPnRs7EPSSnn7sMyBfOXKlejUqRN8fX0tGo5sx8MPP4xVq1ZZdc1r167h119/xSOPPGLVdcl62rZti+DgYKxcudKq6yYkJKCoqAh9+vSx6rpkPX379kV6ejr+/PNPq67LPnR87EPSQnn78LYDuclkQkJCAmJjYy0ejmxH7969sW/fPhw7dsxqa27cuBF5eXno2bOn1dYk6+vZsyfWrl1r1TXXrFmDe++9F/7+/lZdl6ynXbt28Pf3x5o1a6y2JvvQObAPSSvl6cPbDuQ7duxATk4OevfubfFgZDvuv/9+VKtWDQkJCVZbc+3atWjRogUv2OLgYmNjsW3bNly4cMFqa65du5bHLAfn4uKC7t27W/XOHvvQObAPSSvl6cPbDuQbN25EQEAAT8Hj4Dw8PBAdHY1NmzZZbc1NmzahW7duVluP1OjSpQtEBElJSVZZLyMjA1lZWejatatV1iN1unTpgqSkJBQVFVllPfahc2AfklbK04e3Hci3bNmCDh06aBKMbEtMTAw2b95slbXy8vKwZ88etG/f3irrkTp+fn4IDw+32kC+ZcsWuLq6ok2bNlZZj9Tp0KEDcnNzkZKSYpX12IfOg31IWihPH952IP/999+5SZxETEwM0tPTcerUKc3X2rFjB4xGI6KjozVfi9Tr0KGD1QbyrVu34u6774anp6dV1iN1mjZtCj8/P6vtLfah82Afklbu1IelDuTHjx/H6dOncc8992gWjGzHPffcA51OZ5VT1O3cuRMBAQEIDg7WfC1Sr23btti9e7dVzkeenJzMY5aT0Ov1uPvuu61ygSD2oXNhH5JW7tSHpQ7kxU8DNm/eXLtkZDN8fHxQt25dq1zqfO/evYiKitJ8HbINkZGRuHLlCjIzMzVdR0Swf/9+REZGaroO2Y7IyEirvGSFfehc2IeklTv1YakD+d69e1GvXj2eOsyJREVFWe0AxKHJebRo0QI6nU7zwSkjIwOXL1/m3nIikZGROHDgAEwmk6brsA+dD/uQtHCnPix1IE9LS0NERISmwci2REREIDU1VfN10tLSEB4ervk6ZBtq1qyJunXrIi0tTdN1im+fxy3nERERgfz8fGRlZWm6DvvQ+bAPSQt36sNSB/LMzEyEhYVpGswSli5dquQyt1rLzc21+pqhoaGav6wgJycHly9f5t5SyFH3VkZGBry9vW3+KorcV5ZTfBw5evSopuuwD9Vy1GMW+1A9W9tbtx3IQ0JCtMxkEf/4xz/w+uuvq45hEcnJyejVqxf8/PxQs2ZNBAYG4plnnsHly5etsn5oaCjOnj2r6QYt3oShoaGarWEp3FuWExYWpnm5HT161C6KjfvKcgICAlCtWjVkZGRoug770PpU7y324Y24tyynrD40lPbBEydOoF69elpmsohx48YhPz9fdYwq27FjB7p37w6DwYChQ4fCz88P8fHxmDVrFnbt2oXff/8dev1tz1BpEcXv8s7OzkaTJk00WSM7OxsAuLesyBb2Vr169TR/DTmPWdZlC/tKp9Ohbt26OHHihKbrcG9Zly3sLfbhjbi3LKfMPpSbXLlyRQDIypUrb/4UaWTEiBHi5uYmu3btuuHj3bp1EwCyYMECzTNkZWUJAElKStJsjW+//VZq1Kih2e3TrWxhb02ZMkXq1aun6RqxsbHy5JNParoG/Y8t7CsRkfbt28vEiRM1u332ofXZwt5iHzomW9hbZfRh6i13BXJycgAAtWrV0uLOwS1Gjx6NESNG4PDhw3j66acRHByMrl27Ii4uDgDwr3/9C23atEHt2rURGxt7w4vhJ0yYgCeffPKG2xo3bhyys7MxdOhQhISEoGHDhhg1ahTy8vIsti4AbNiwAc8//zyaNGmC4OBgPPbYY5gxY8YN7/ifN28eOnbsiHffffeG7/3111/RpUsXvP/++wCuXwWuVatWaNWq1Q1fV/yzbd++vVK/24oo/nsX//21kJOTYxf7Cqj83qrqusCd91Z59xVgO3vr3Llzmq5x7tw5u9hbN++r4tuzt71lC/sK0H5vsQ/Zh1phH7IPb3HziL5nzx4BIIcOHdL8noKISNu2bSUwMFCCgoKkWbNmMnz4cHFzcxOdTiexsbFiMBikb9++0q9fP3Fzc5P69euLyWQq+d6wsLAbbis0NFTq1q0rHTp0kFdffVU6deokAKR///4WW/fXX38VFxcX8fPzk3HjxsnkyZMlJiZGAMgrr7xSskZBQYE0b95c9Hp9yT3tK1euSEhIiHh7e8vRo0elsLBQxo0bJ999990tv5sPPvhAAMj7779v8d97aTw9PUvNYSlvvfWWtGrVSrPb/6uq/H2Lv78ye6uq65Znb5VnX4mIzeytZcuWCQDJz8/XbI0mTZrIP/7xD81u/68secwq/pg97S1b2VciIk888YQ89NBDmt0++5B9qBX2IfvwJqm3DOTbtm0TAJKZmal5MJHrfzAAN5TpqlWrBIB4enrecCAcMWLEDQfH0jYJAHnttdfEbDaLiIjJZJK7775bvL29Lbbu6NGjxd3dXS5cuFDyNfn5+VKnTh2JiIi4YZ2dO3eKq6urRERESEFBgTz33HMCQOLi4sr8vZw+fVrq1asnrq6ukpKSUvYv0UJ8fHzk66+/1uz2//a3v0m7du00u/2/qsrft/j7K7O3qrpuefdWZfeViPX31tq1awWAXLp0SbM1QkJC5JNPPtHs9v/Kksesv96eve8tFces0aNHS8+ePTW7ffYh+1Ar7EP1xywRm+rDWwfyxMREASDZ2dmaBxO5/gdzcXGRa9eulXzsxIkTAkAefPDBG772P//5jwCQJUuWlHzvzZvE09Pzlnse48ePFwCSlZVlkXX//PPPW/5wly5dkqZNm0pQUNAtP+O7775bcrs6nU6GDBlS5u9k+fLlUrt2bdHpdPL555+X+bWWVLt2bZk2bZpmtz9+/Hjp2LGjZrf/V1X5+xZ/f2X2VlXXrcjequi+ElGztzZs2CAA5MyZM5qtERgYaLWfx5LHrOKP2fveUnXMev7556VTp06a3T77kH2oFfYh+/Amt76G3Gg0AgBcXV1v/pRmgoKC4ObmVvLfHh4eJR//KxcXFwBAYWHhbW+rdu3aJd9frPjcxDefwqiy60ZERCAoKAhTpkzBwIED0bZtWwQHB+PPP/8sNdMbb7yBe++9FytXrkRQUBCmT59e6tcdOXIEffv2xUMPPQQvLy+sW7cOEyZMuO3Pamlubm64du2aZrdvNBphMJR6Yh9NWHJfAeXfW1VZtyJ7q7z7ClC7t4p/F1ruraKiIrs9ZgH2u7ds4Zh1p99tVbAP2YdaYR+yD292y0BevEGKioo0jvU/1atXL/XjlTn9jKen520/JyIWWfeTTz5BvXr18N5778FoNKJ79+6YM2cOYmJiyr32zeLi4tCqVSts2LABH3/8Mfbt24fu3buX+T2WZjQaNS0eg8Gg+WWu/8qS+woo/96qyroV3Vt32leA+r1ljaHGxcXFbo9ZgH3uLdX7CtB+qGEfsg+1wj5kH97sliNZ8fSu5aMO9uzs2bN4/fXXcddddyEtLQ01a9Ys+dw///nPUr/nn//8J/744w/ExsZi9erVGDduHH744YeSz69YsQJPPPEE2rdvj/nz56N+/fqa/xylKSwshLu7u2a37+7uzn1VhorurTvtK8A29lbxIwHcW+pYem/Zwr4CtD9msQ/Lxj6sPB6zyuaMfXjLXZTiL+JGKd3Ro0dhNpvRv3//GzZIVlYWdu/efcvX79y5E//4xz/Qvn17rFixAg899BDmzZuHhQsXlnzNm2++CW9vbyxatEjZwQewTrlp+RSgvavI3irPvgJsY28VH0tYbupYem/Zwr4Crpeb1vsKYB/eDvuw8tiHZXPGPrzlEXJvb28AwMWLFzWOZZ/Cw8NRo0YNxMfHIzY2FhEREUhKSsI777wDLy8v5Obm4tChQwgPD0dBQQGGDx8OvV6Pb775Bnq9HjNmzEBiYiKeffZZdOzYEe7u7ti3bx9at26NKVOmlLpm586d0adPH01/rsLCQly9erXk768Fb29vXLp0SbPbt3fl3VshISF33FeBgYG4cOGCTeytCxcuwM3N7ZbXG1qSl5cX91YZLLm3bOWYBVzvKR8fH81un31YNvZh5bEPy+aMfXjLQO7v7w8Aml/Iw17VrFkTs2fPxqhRo9C3b18AgJ+fHz777DNUr14dI0aMQIsWLWA0GvHmm2/izz//xOTJk9GsWTMA19/I8Nlnn+HJJ5/E008/jbFjx0JEkJycjOTk5FLX1Ol0mm+Sc+fOQUQ0vVCBv78/91UZyru3xo8ff8d9tWLFCiQlJdnM3vL394dOp9NsDe6tsllyb9nKMQu4vrdCQkI0u332YdnYh5XHY1bZnLEPdVLKq+Dd3d0xe/ZsPP7445oGs2c5OTnYtWsX6tSpg2bNmpX8cnNycnDhwgU0atRIccKK2bt3L6KionDgwAE0bdpUkzWWLFmC/v3749q1aze865pu5Gh765133sHSpUuRkpKi2RqPP/448vLy8PPPP2u2hiNwtL0VERGBoUOH4v/+7/80W4N9eGeOtq/Yh7bD0fZWGX2YVurb0wMCApCdna19Mjvm7+9f6jtz/f39Sx5VsSfFf+/AwEDN1qhTp07JWqGhoZqtY+8cbW+dPHkSAQEBmq4RGBiIxMRETddwBI64t7Q8ZgHsw/JwtH3FPrQdjra3yurDUs87ExoaiszMTC0zkY3JyMiAt7d3yXlEtVD81PLRo0c1W4NsT0ZGBsLCwjRdIyQkhMcsJ5OTk4PLly9rvrfYh86HfUhaKasPOZATACAzM1PzYgsMDES1atWQkZGh6TpkWzIyMjR/BCgsLAxnz5695WIn5LiKO0rrvcU+dD7sQ9JKWX1Y6kDeqFEjpKamapmJbExaWhoaNmyo6Ro6nQ5hYWHcW06koKAAWVlZmr/Or/j209LSNF2HbEdqaipcXV01fVMnwD50RuxD0sKd+rDUgTwyMhLp6el8tMmJ7NmzB1FRUZqvExUVhb1792q+DtmGAwcOoKioSPO91bhxY3h4eGj6xlGyLSkpKQgPD9f8DXHsQ+fDPiQt3KkPSx3Io6KiYDabsX//fk3DkW3Iy8tDRkYGIiMjNV8rMjKSQ5MT2bt3Lzw8PDR/hNxgMKBZs2YsNydSfCYMrbEPnQv7kLRypz4sdSAPCwuDl5fXbc/VSI5lz549MJvNaNmypeZrtWrVCllZWTz/qpPYtWsXWrRoAYOh1BM6WVTLli15zHIiu3fvtsoxi33oXNiHpJU79WGpA7ler8d9992HLVu2aBqObENiYiICAwPRoEEDzddq3749dDodtm7dqvlapN7mzZsRExNjlbWio6Oxfft2FBUVWWU9Uic9PR0nTpxAdHS05muxD50L+5C0cqc+LHUgB66XW1JSkiahyLYkJSWhY8eOVlnLx8cHTZs25d5yAnl5edizZ49VB/LiNcmxJSUlwd3dHW3btrXKeuxD58E+JC2Upw9vO5B36NABGRkZyMrK0iQc2QaTyYSkpCR06NDBamt26NABmzZtstp6pMbmzZthMpmstreaNm0Kf39/bNy40SrrkTobN27EPffcAw8PD6usxz50DuxD0kp5+rDMgbxGjRpYs2aNJuHINmzbtg3nz59Hz549rbZmjx49sH37duTk5FhtTbK+NWvWIDIysuSKdFrT6XTo0aMHj1lOYN26dVY9ZrEPnQP7kLRSnj687UDu7u6OTp068QDk4NauXYvQ0FBERERYbc0ePXpAr9cjISHBamuS9a1Zswa9e/e26pq9e/fGpk2beIo6B7Z3715kZWVZdW+xD50D+5C0Up4+vO1ADgAPPPAAEhISkJ+fb9FgZDuWL19u9aHJy8sL0dHRWL58uVXXJetJS0vDwYMHlQzkRqMR69evt+q6ZD0rVqxA7dq10aZNG6uuyz50fOxD0kJ5+7DMgbx///64evUqVq9ebdFwZBtSU1Oxa9cuDB482OprDxw4EMuWLWO5Oaj4+HjcddddVntzVLGAgAB07NgRCxYssOq6ZD0//vgjBgwYAL2+zPqyOPahY2MfklbK24dlHtECAwPRsWNHLFy40KLhyDbEx8cjMDAQ999/v9XXHjhwIPLz81luDmrBggUYPHiwVc4/frPBgwdj2bJlyMvLs/rapK1Dhw4hJSUFQ4YMsfra7EPHxj4krZS3D+/4EMOjjz6KZcuW4dKlSxYLR7Zh3rx5GDhwIFxcXKy+dmBgIDp16oS4uDirr03aSklJwd69e5UMTQAwYMAAXLt2DcuWLVOyPmknLi4OQUFBVj0Lxl+xDx0X+5C0UJE+LNdArtPpMG/ePIuEI9uQmJiIgwcPYtSoUcoyPPXUU1i+fDmys7OVZSDL++abb9CkSRNlQ1NAQAD69OmDr7/+Wsn6pA2TyYS5c+di5MiRSoYmgH3oqNiHpJWK9OEdB3Jvb28MHjwYs2bNskg4sg3ffPMN2rRpg9atWyvL0L9/f3h7e2Pu3LnKMpBl5efnIy4uDqNGjYJOp1OWY/To0diwYQNSU1OVZSDLWr16NY4fP650aGIfOib2IWmhon1YrnfFPPPMM9i9ezcSExOrHJDUO336NBYsWIAxY8YozeHh4YERI0Zg+vTpMBqNSrOQZcTFxeHq1asYOXKk0hy9evVCSEgIpk2bpjQHWc6XX36Jbt26oWHDhkpzsA8dC/uQtFLRPizXQN6uXTtER0djypQpVclGNuLLL7+El5cXhg8frjoKJkyYgJMnT/KsGA5ARPDZZ59h2LBhCAgIUJrFxcUFL7zwAr799ltecMMBpKSkICEhAX/7299UR2EfOhj2IWmhMn1Y7vNGvfzyy1i+fDkOHTpU6YCkXm5uLmbMmIHnnnsOnp6equMgJCQEAwYMwJQpUyAiquNQFSxbtgwHDx7ESy+9pDoKgOuvyXRzc8PMmTNVR6Eq+uSTT9CiRQurXkGxLOxDx8A+JK1Uqg+lnIqKiiQiIkIef/zx8n4L2aAPPvhAatasKWfPnlUdpURycrLodDpZunSp6ihUSWazWe6++255+OGHVUe5wZtvvim1atWSy5cvq45ClXTw4EFxcXGRuLg41VFKsA8dA/uQtFDJPkwt90AuIjJ//nzR6/WSkpJSsXRkEy5duiR+fn7y9ttvq45yi379+klkZKSYTCbVUagSFi9eLDqdTnbt2qU6yg0uXLggPj4+8t5776mOQpX06KOPSpMmTaSoqEh1lBuwD+0b+5C0Usk+rNhAbjKZJDIyUh555JGKpSOb8Pbbb4uPj49cuHBBdZRb7N27V/R6vfzwww+qo1AFGY1Gad68uQwaNEh1lFJNnjxZfHx85MyZM6qjUAXt2rVL9Hq9LFiwQHWUW7AP7Rv7kLRQhT6s2EAuIrJu3ToBICtWrKjot5JCaWlp4uHhIf/6179UR7mtp556SgIDA+XixYuqo1AFfPrpp+Lu7i6HDh1SHaVUly9flrp168qoUaNUR6EKMJvN0r59e4mJiRGz2aw6TqnYh/aJfUhaqUIfVnwgFxEZNGiQNGzYUPLz8yvz7aTAAw88IC1atJDCwkLVUW4rJydHatWqJRMnTlQdhcrp5MmT4u3tLZMnT1YdpUzx8fGi0+lkw4YNqqNQOX3zzTfi4uJicy+Duhn70P6wD0kLVezDyg3k2dnZ4u3tLZMmTarMt5OVLVq0yG6GkVmzZonBYLD5EqbrBg8ebDfDiD2UMF2Xk5Mjd911l7z44ouqo9wR+9C+sA9JK1Xsw8oN5CK2/zQ1XZeXlyehoaEycuRI1VHKxWQy2fzT1HRdQkKCXT1dX/w09WeffaY6Ct3BmDFj7OrpevahfWAfklYs0IeVH8iNRqNERkZKz549uVFs2EsvvSS+vr5y+vRp1VHKLTk5WVxcXGTWrFmqo9Bt5OXlSXh4uPTr1091lAp55513xMvLS44ePao6Ct1GUlKS3b2hjX1oH9iHpAUL9WHlB3IRkd9//11cXV3l448/rsrNkEZWrVoler1e/vOf/6iOUmGvvfaaVK9eXfbv3686CpVi1KhR4ufnJ8eOHVMdpUKuXr0qzZs3l+joaL50xQbl5ORISEiIPPDAA6qjVBj70LaxD0krFurDqg3kIiIff/yxGAwG2bx5c1Vviizo+PHjUqtWLXn00UdVR6kUo9EoMTEx0rx5c8nLy1Mdh/5i/vz5otPpZMmSJaqjVMq+ffukWrVq8uqrr6qOQn9hNpvlkUcekXr16tnUhVoqgn1om9iHpBUL9mHVB3Kz2SwPP/ywBAcH2+1B1NEYjUbp2LGjNG7c2K6vUHjs2DHx9/fn6epsSGpqqtSsWVNefvll1VGqZPbs2aLT6eTnn39WHYX+a8qUKWIwGCQxMVF1lEpjH9oe9iFpxcJ9WPWBXETk/PnzJU8z8vVz6r3xxhvi4eHhEO/MXrFiheh0Opk7d67qKE4vPz9fWrVqJffee69cu3ZNdZwqGzFihPj6+kpmZqbqKE5v+/bt4ubmJh988IHqKFXGPrQt7EPSggZ9aJmBXERk8+bNYjAYeIlqxZYsWSJ6vV6++eYb1VEs5qWXXpLq1atLcnKy6ihOy2w2y7BhwxxqgM3NzZWmTZvKfffdx6eBFcrOzpaQkBCJjY11mEuFsw9tA/uQtKBRH1puIBcRmTZtmuh0Oofa/PZk06ZN4unpKWPHjlUdxaIKCwule/fuEhAQIIcPH1Ydxym9+uqr4urqKmvXrlUdxaIOHDgg/v7+0qdPHzEajarjOJ2LFy9Ky5YtJTw8XM6dO6c6jkWxD9ViH5JWNOpDyw7kIiJvv/22uLi4yOLFiy1901SGvXv3iq+vr/Tt21eKiopUx7G4vLw8ad++vTRo0EBOnjypOo5TKR4s5syZozqKJrZt2yY1atSQYcOG8SUGVnTt2jXp0aOHBAUFSUZGhuo4mmAfqsE+JK1o2IeWH8hFRMaPHy+enp6yadMmLW6ebpKVlSXBwcHSqVMnu7hiYmWdPXtWwsPDJTIyUi5cuKA6jlOYN2+e6PV6+fTTT1VH0VRCQoK4ubnJa6+9pjqKUzCZTDJw4EDx9vZ2iNf2loV9aF3sQ9KKxn2ozUBeVFQk/fr1E19fX9mzZ48WS9B/nTlzRsLDw6Vly5Z2c1W7qkhPT5c6depIly5dHPpgawtWr14trq6u8sorr6iOYhXfffed6HQ6mTJliuooDs1sNsszzzwjHh4eTjGksg+th31IWrFCH2ozkItcfwdq586dxc/PT7Zs2aLVMk4tMzNTwsPDpWHDhpKdna06jtXs2bNHfH195f777+cjAxpZuHChuLu7y4gRI5zqZRxTpkwRnU7HN+NpxGg0ysiRI8XV1dVuz2NfGexD7bEP2YdasVIfajeQi4gUFBTIgAEDpFq1arJiZdk1VwAAGYxJREFUxQotl3I6+/btk3r16knz5s0lKytLdRyr279/vwQHBzvtz6+lr776SvR6vTz//PMOc9aLipg9e7YYDAan/fm1UlBQIP3793faPmAfaod9yD7UihX7UNuBXOT603WjR48WFxcX+frrr7Vezils3bpV/P39pVOnTk7xtNztZGZmSkREhISGhsrBgwdVx3EIH374oQBw+tdSL1myRDw8PKRfv358KtgCzp8/Lx06dBBfX1+nvool+9Dy2IfXsQ8tz8p9qP1ALnL9NYOvv/666HQ6+eijj6yxpMNasmSJeHp6Sv/+/TkoyPU3ttx7771Su3Zt2b59u+o4dstoNMqYMWM4KPzFr7/+Kl5eXtKtWze5dOmS6jh269ixY9KsWTOpX7++HDhwQHUc5diHlsM+vBH70DIU9aF1BvJiU6dOFb1eL0OGDGHBVZDRaJQ33nhDdDqdjB071iFP5VRZV65ckd69e4uHh4dMnz5ddRy7c/z4cenYsaN4enryUvI3SU5OlsDAQGncuLHDnw1EC6tWrZJatWpJixYt+FT6TdiHlcc+vD32YdUo7EPrDuQi1x91qlOnjoSGhsq2bdusvbxdysrKko4dO4qHh4dMnTpVdRybVFRUJJMmTRIXFxfp168f39xSTuvXr5fAwEBp0qSJ7N69W3Ucm3T69Gnp2bOnuLu78/+/cjIajTJp0iTR6/UybNgwuXLliupINol9WHHswztjH1aO4j60/kAuwoKriPXr10tAQICEh4dzYCoHFlz5cGCqGBZc+WVlZUmHDh04MJUT+7D82IcVwz4sHxvpQzUDucj1gvu///s/0ev1MnDgQF5t6ia5ubny0ksviU6nk+HDh3NgqoDs7Gzp0qWLeHh4yJQpU3hJ9Jv8+eefEhMTI56enrysdwUlJCRIQECANG7cWDZu3Kg6js2Jj4+XWrVqSdOmTWXv3r2q49gN9mHZ2IeVxz4smw31obqBvNj69eslNDRUvL295fPPP+drwURk0aJFEhwcLL6+vjJ79mzVcexSUVGRvPvuu+Lu7i4tW7Z06jM7FMvLy5M33nhD3NzcpHXr1hyYKunkyZPywAMPiE6nkyeeeEJOnTqlOpJyhw4dkh49eohOp5Onn35acnNzVUeyS+zDW7EPq459eCsb7EP1A7mIyNWrV2XSpEklmyUpKUl1JCUOHz5cUvTDhw9n0VvA4cOHJTY2tuR3evr0adWRlFi2bFlJ0U+dOpVFbwHFv1MfHx+n/Z3efOxm0Vcd+/A69qHlsQ+vs9E+tI2BvNjBgwele/fuotPp5KmnnpLjx4+rjmQVly5dkrffflvc3d0lMjJSEhMTVUdyOAsXLpR69eqJn5+fTJs2Ta5du6Y6klXs37+/pNSGDRvGp8ItLDc3V15//XVxc3OTNm3aOM3LWMxmsyxcuFBCQ0PFy8tLpk6dyqfCLYx9yD7UCvvQJvvQtgbyYj/++KMEBweLh4eHvPjiiw57zzg3N1c++OAD8fPzEx8fH76+S2NXrlyRV155Rdzd3SU0NFS+/fZbh/19p6amyrBhw0Sv10tUVJRs2LBBdSSHduDAAenevbsAkB49esjWrVtVR9LMsmXLpFWrViVvgHKmy5SrwD4kLbAPbY5tDuQiIteuXZOZM2dKUFCQuLu7y/Dhwx3mohJnzpyRSZMmib+/v1SvXl1ee+01OX/+vOpYTiMrK0smTJgg7u7uUqdOHZk0aZLDnDUjOTlZhg8fLgaDQcLCwmTmzJm28nScU0hMTJQuXboIAImJiZFly5aJ2WxWHavKCgsLZcGCBXLPPfcIAOnevbvs3LlTdSynwT4krbAPbYbtDuTFrl69Kl999ZU0atRI9Hq9PPjgg7J06VK7vCeXmJgoTzzxhHh4eMhdd90lkydPlrNnz6qO5bQyMjJkwoQJUqNGDfHx8ZEJEyZISkqK6lgVdvXqVZk7d6506NBBAEibNm1k/vz5tnzgcXgJCQnSq1cv0el00rRpU/nss8/k3LlzqmNV2NGjR2Xy5MlSr149MRgMMnToUElOTlYdy2mxD0kr7EPlbH8gL2YymWTx4sXSo0cP0ev1EhQUJH/729/kjz/+UB2tTKmpqfLee+9JREREyeaYOXOmXL16VXU0+q/z58/Lhx9+KI0aNRIA0q5dO/n888/lxIkTqqPdVlFRkfzyyy8yZswY8fHxETc3Nxk4cKD8+uuvqqPRX6SkpMiYMWPEy8tL3N3dZciQIfLTTz/Z9GW+L1y4IHPmzJHevXuLXq+XgIAAefXVV+Xo0aOqo9F/sQ9JK+xDZexnIP+r9PR0eeedd0o2TIMGDWTixImybt065UVXVFQkW7ZskXfeeUdat24tACQgIEDGjRvHR5ZsnNlslt9++02eeOIJ8fLyEr1eL/fff7989NFHsmfPHtXx5NKlS/LTTz/JmDFjJCAgQABI69at5dNPP3Xad8vbi9zcXPn222+lc+fOotfrxcvLSx599FGZO3euTbwmOD09Xf79739Lnz59xN3dXdzd3aVv376yePFiKSwsVB2PysA+JC2wD60uVSciAju2c+dOLFiwAKtWrcK+fftQrVo1REdHIyYmBjExMWjbti18fX01Wz8vLw979uxBUlISNm/ejM2bN+P8+fMICQlBbGwsBg4ciM6dO8PFxUWzDGR5BQUFWLNmDRYvXoy1a9fi7NmzCAoKwv3331+yv1q0aAE3NzfNMpw6dQrbt2/H5s2bkZSUhD/++AMmkwn33HMP+vTpg8GDB6NJkyaarU/aOHnyJBYtWoRly5YhMTERRqMRkZGR6NixI6Kjo3HfffchLCxMs/VNJhPS0tKwdetWJCYmYvPmzUhLS0ONGjXQrVs39OvXDw8//DB8fHw0y0DaYB+SFtiHVpFm9wP5X2VlZWHdunXYtGkTkpKScOTIEQBAcHAwIiMjER4ejrCwMISFhSE4OBj+/v6oVasWPDw8Sm5jyZIl6NevX8l/G41GnDt3Djk5OThx4gQyMzORkZGBtLQ0pKSkID09HWazGYGBgYiJiUHHjv/f3r3H1nz/cRx/nepBW1qUTUloUWxWOuKyiVlMFMNmm2WzS9w2sQTZll0wiS1is8RiQyyWuGuNzohiiAmjU6O07qotcW+1pdWWHj3n94c5v521pR2nn3N5Pv4733PSvipf5/3qp5/v9/RRXFycOnbsWOs/P9zDbrcrNTVV27dv1549e5ScnKzr16/LarWqQ4cOeuqppxQdHa3IyEhFRUWpefPmCg8PV3h4uHPw2O12bdy4US+99JLz6xYXFysvL09Xr17VhQsXlJ2drezsbJ04cULp6enKzc1VQECAnnzySfXu3Vt9+/bVgAEDFB4ebuqfAo9YcXGxdu7cqd9//13JyclKTU2VzWZTaGioYmJi1KlTJ+d7VqtWrfTYY4+pWbNmCg0NdX6NP//8U5GRkYqIiHAey8vLU15ennJycpSdna2zZ88qKytLR44c0fHjx1VaWqrg4GB1795dffr0Ub9+/dS7d2+3DlTULuYh3IF56Da+Vcj/7cqVKzp06JDS09OVnp6ujIwMnT17Vrm5uS6vCwkJUd26dWWxWFRYWKhGjRqpvLxc5eXlKiwsdHltWFiYIiMj1a5dO8XExCgmJkaxsbFq06ZNbf5oMMhut+vkyZNKT09XWlqajh07pszMTJ09e1YlJSUur723GmWxWFRSUqKgoCBJUmlpqW7duuV8ncViUUREhKKiotShQwfnudW1a1e3rmjBs5SUlOjw4cM6cuSI0tLSdOLECWVnZ+vixYu6c+eO83VWq1UNGjSQdLck1alTRwEBAZKkwsJClZeXO19bt25dtW7dWlFRUerUqZNiYmLUuXNnde7cWVartXZ/QBjDPIQ7MA8fGd8u5FUpLi7WhQsXnKtI+fn5un37to4fP67vv/9ew4cP18CBAxUYGKgmTZo4f7uLiIjw5ZMBj8DVq1eVm5vrXEUqKCiQ3W7XsmXLlJycrFmzZik8PFzBwcHOc6tp06Zq2bKly8oU8E82m02XL19WTk6O8z2rqKhIdrtdH330kcLDwzV9+nRJUqNGjZznVdOmTRUREeEs68C/MQ/hLszDGvHPQl6VMWPGaMmSJYqJiVF6errpOPARNptNTZs2VWFhob7++mt9/vnnpiPBR2zZskWDBw+WJJ0+fVrR0dGGE8FXMA/hDszDKmWwbPK327dva+3atZKkI0eO6NSpU4YTwVds3brV+afeZcuWGU4DX5KQkCCr1Sqr1aqff/7ZdBz4COYh3IV5WDUK+d82b96s4uJiSXf3XCYkJBhOBF+xcuVK517dkydP6ujRo4YTwRfcunVL69atk81mk81m05IlS0xHgo9gHsJdmIdVo5D/bdWqVQoMDJQklZWVaenSpWYDwSeUlJRow4YNstlsku4Ot9WrVxtOBV+wceNGl4umsrKylJaWZjARfAXzEO7APLw/CrmkoqIiJSUlOU8SSTp37pwOHjxoMBV8wYYNG3T79m3n47KyMi1btkxcuoGHtXLlSpf7OVutVlYy8dCYh3AX5uH9UcglrV+/3uXNR2K44dFYuXJlhTtcXLhwQSkpKYYSwRcUFhZqy5YtLrdCtNlsWr58OcMND4V5CHdhHt4fhVx3TxKLxeJy7N5w++f9fIGaKCgo0LZt2yqcQ+zJxMNKTEyU3W6vcPzy5cvau3evgUTwFcxDuAPz8MH8vpBfu3ZNO3bsqPSNJjc3V3/88YeBVPAFa9eurbQ0lZWVacWKFS6rm0BNrFixotLjrGTiYTAP4S7Mwwfz+0K+Zs2aKp+zWq2Kj4+vxTTwJVWVJunuasHOnTtrMQ18RU5Ojnbv3l1pabLZbIqPj6+w5QCoDuYh3IV5+GB+X8jvt+fSZrNp9erVKisrq+VU8HaXLl1ScnJypSsCEsMN/11CQsJ9P3nz+vXr2rFjRy0mgq9gHsIdmIfV49eF/Pz589q/f3+VJ4kk3bx5U1u3bq3FVPAFDypNNptNa9asUWlpaS2mgi940F5ehhv+C+Yh3IV5WD1+Xcirs9fSYrFo1apVtZAGvmTFihUPvACqpKREW7ZsqaVE8AVZWVk6dOjQfe+kYrPZlJiY6PfDDTXDPIS7MA+rx68L+erVqx94izC73a6NGzc6P7UMeJCMjAylpaVV6/ZzfCgCaqI671mSVFpaqqSkpFpIBF/BPIQ7MA+rz+Lw45vWFhQUuDzOz89Xu3bt9Ouvv6pv374uz4WGhrp8CAdQlbKysgoDa8mSJZo5c6YyMzNdjgcEBCgsLKw248GLFRcXV9jD+/LLL6tt27aaM2eOy/H69esrKCioNuPBizEP4Q7Mw2rLCDSdwKTGjRu7PL63d65hw4YVngOqq27duqpbt67LseDgYFksFs4rPJSQkBCFhIS4HAsMDFS9evU4t/BQmIdwB+Zh9fn1lhUAAADANAo5AAAAYBCFHAAAADCIQg4AAAAYRCEHAAAADKKQAwAAAAZRyAEAAACDKOQAAACAQRRyAAAAwCAKOQAAAGAQhRwAAAAwiEIOAAAAGEQhBwAAAAyikAMAAAAGUcgBAAAAgyjkAAAAgEEUcgAAAMAgCjkAAABgEIUcAAAAMIhCDgAAABhEIQcAAAAMopADAAAABlHIAQAAAIMo5AAAAIBBFHIAAADAIAo5AAAAYBCFHAAAADCIQg4AAAAYRCEHAAAADKKQAwAAAAZRyAEAAACDLA6Hw2Hqm9+4cUN9+/Y19e0rcDgcys/PV2hoqKxWq+k4TosWLVKPHj1Mx/AqiYmJmjlzpukYTrdu3VJJSYmaNGliOopTWFiYdu3aZTqG13n//fe1f/9+0zGcCgsLVadOHYWEhJiO4jRixAhNmzbNdAyvwjysHuZhzTEPH8wD5mFGoMnvfufOHaWlpWnkyJFq3bq1ySgeqbS0VHPnzlVRUZHpKF7n2rVrOnXqlD788EPTUTzSoUOHlJKSYjqGVzpz5owCAgI0cOBA01E8Unx8vM6fP286htdhHt4f8/C/Yx7en6fMQ6OF/J4xY8bohRdeMB3D4+Tl5Wnu3LmmY3itoKAgzZo1y3QMj/Tjjz96xBuQt+rRowfnVhX27dtnOoJXYx5Wjnn4cJiHVfOUecgecgAAAMAgCjkAAABgEIUcAAAAMIhCDgAAABhEIQcAAAAMopADAAAABlHIAQAAAIMo5AAAAIBBFHIAAADAIAo5AAAAYBCFHAAAADCIQg4AAAAYRCEHAAAADKKQ/4vdbjcdAQBq5ObNm6YjwMfcuXNH5eXlpmPAhxUVFSkvL890DI9BIZd0+vRpTZ48WZGRkQoPD9eQIUO0Y8cO07HgY6Kjo/Xee++ZjgEfkZqaqri4ODVp0kQNGzZU8+bNNX78eBUWFpqOBi+2atUqPfvss2rYsKHq16+vjh07av78+SxW4ZHKy8tTx44d1adPH9NRPIbfF/LS0lINGzZMixcvVlxcnCZMmKCMjAwNHTpUu3fvNh0PPmLp0qU6c+aM6RjwEQcOHFC/fv108OBBjRw5UtOnT1dYWJgWLVqk/v37U57wnyxfvlzvvPOOCgoKNHnyZH3wwQe6efOmJk6cqFmzZpmOBx8yduxYXbp0yXQMjxJoOoBp06ZN06lTp7R582YNGjRIkjR58mR16dJFo0aNUlZWluGE8FYXLlzQl19+qb/++ktpaWmm48CHzJ8/X6WlpUpJSVFsbKwk6auvvlL//v21Y8cO/fLLLxoxYoThlPA2c+bMUXR0tFJSUhQaGipJ+uyzzxQVFaUFCxboiy++MJwQvmDhwoX67bff1KRJE9NRPIrfr5AvXbpUnTt3dpZxSXr88ccVFxen7OxspaSkGEwHb1ZUVKTTp08rLCxM3bt3Nx0HPiQ5OVmxsbHOMn7P6NGjJUn79+83EQte7MaNGzp69KgGDRrkLOOS1KJFC/Xr10/5+fmy2WwGE8IXHDt2TB9//LFmz56tiIgI03E8il+vkF+7dk0FBQXOIfZP7du3l3T3T8M9e/as7WjwAU888YR27dolSTpz5oyio6MNJ4IvsNlsiouLU48ePSo8d/78eUli5Qk1FhgYqN27d6tNmzYux2/cuKH09HQNGDBAVqvVUDr4glu3bunNN99Unz59NGnSJP3000+mI3kUvy7kp06dkqRKf0vr0KGDJCknJ6dWMwHA/VitVs2bN6/C8ZycHC1YsEBWq1VDhgwxkAzeLCQkRL1793Y+njt3rs6dO6dNmzapvLxcU6ZMMZgOvuCTTz7RpUuXtHXrVlksFtNxPI5fF/J7F9lVtprUunVrSdL169drNRMA1FRSUpLGjh2r3NxczZ07VzExMaYjwctNmzZNJSUlkqROnTopKCjIcCJ4s6SkJM2fP1/r1q1jq0oV/HoPeb169SRJ+fn5FZ4rLi6WJDVu3LhWMwFAdWVmZmrYsGEaOnSoQkNDtW3bNk2aNMl0LPiA4uJinT59WosXL1ZeXp569uypK1eumI4FL3T58mWNHj1a48aN0/Dhw03H8Vh+vULevHlzSar0Tir3SnqzZs1qNRMAVMfKlSs1YcIEWSwWffvtt5o0aZJzkQGoKYfDIYfDoYCA/6/TRUdHKzo6WgEBARo1apQ2b96sMWPGGEwJb7Rw4UJdu3ZNN27ccLlm7+LFi3I4HBo9erTat2/v99ui/LqQt2/fXhaLpdJCfu82dVzQCcDTJCUl6d1339UzzzyjhIQEtWrVynQkeLlvvvlGU6dO1aZNmzR48GCX55o2bSrp/xcNAzXRrFkzxcbGKiMjw+X47du3ZbfbdfjwYZdfBP2VXxfyFi1a6LnnntPu3buVmZmptm3bSrp7F4P4+Hi1bNlS3bp1M5wSAFxNnTpVYWFhSkxMZD8mHol71x1s3769QiG/dzeMLl261HoueL+JEydq4sSJFY5369ZNpaWlOnTokIFUnsevC7l0d7C9+OKLev311zVt2jQ1btxYs2fPVlZWlpKSkrgSGIBHKSgo0NGjR/X0009rzpw5lb7m+eef504rqJHBgwcrJiZG8+bNU6NGjRQXF6eLFy9q7dq12rhxo7p37845BbiR3xfyAQMGaMWKFRo3bpxeffVVSVKjRo303XffuXxYEAB4gr1798rhcCg1NVWpqamVvsZisVCeUCMBAQFav3693n77bc2YMUMzZsxwPvfKK6/ohx9+UGCg31cGwG343yXpjTfe0GuvvaYDBw7IbrerZ8+eqlOnjulY8CHt2rWTw+EwHQM+YMiQIZxLcIs2bdpoz549ys7O1smTJxUUFKQOHTqoZcuWpqPBBx08eNB0BI9CIf9bYGCgevXqZToGAADGBAQEqG3bts5rqgDUDi5rBQAAAAyikAMAAAAGUcgBAAAAgyjkAAAAgEEUcgAAAMAgCjkAAABgEIUcAAAAMIhCDgAAABhEIQcAAAAMopADAAAABlHIAQAAAIMo5AAAAIBBFHIAAADAIAo5AAAAYBCFHAAAADCIQg4AAAAYFGg6gCSNHz9eDRo0MB3D45SXl5uO4NUKCwsVGxtrOoZHysvLMx3BqyUmJmrfvn2mY3ikzMxMtW/f3nQMr8U8rBzz8OEwD6vmKfPQaCEPDg7WlClTTEbweEOHDlVkZKTpGF6na9eu+vTTT03H8GjBwcGmI3ilt956S7169TIdw6P17NnTdASvwzx8MObhf8M8fDBPmIcWh8PhMB0CAAAA8FMZ7CEHAAAADKKQAwAAAAZRyAEAAACD/geKWjIheE/iNwAAAABJRU5ErkJggg==",
+                        "text/plain": [
+                            "<IPython.core.display.Image object>"
+                        ]
+                    },
+                    "execution_count": 14,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "p.visualize()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 15,
+            "id": "1bed1d4e-0f2f-46ed-a7e8-905c07dedcf2",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "CPU times: user 11.2 ms, sys: 3.16 ms, total: 14.3 ms\n",
+                        "Wall time: 2.01 s\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/plain": [
+                            "0     4\n",
+                            "1     4\n",
+                            "2     8\n",
+                            "3     8\n",
+                            "4    11\n",
+                            "5     4\n",
+                            "6     6\n",
+                            "7     0\n",
+                            "8    10\n",
+                            "9     2\n",
+                            "dtype: int64"
+                        ]
+                    },
+                    "execution_count": 15,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "%%time\n",
+                "q = ddf.apply(minmax, axis=1, meta=(None, 'int64'))\n",
+                "q.compute()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 16,
+            "id": "a9cca26f-3175-4eb2-a4d0-a24c6d2c5e8b",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhwAAAEhCAYAAAA08nmSAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVyU9f4+/msGhkVQEcQFN0RZ1EPa11zQ40aWaS7HFJdSs2w5VuppsdLytHxOHa0sSzudNlNxxSVzy0yltCDUVFwScEEEcQPZZZ15/f7wB0cCcQbmnnvu4Xo+HjweNY7zvuDtXPOa4Z57dCIiICIiIlKOSa92AiIiInJ8HDiIiIhIcRw4iIiISHHOlv6FqKgoJXI4lD59+qB169Zqx6gkNTUVsbGxasewazqdDhEREWrHqCI2Nhapqalqx7Brbdq0QVhYmNoxqmBf3hn7Uptq1ZdiAZPJJAD4dYevqKgoS36sNrF27VrVfy5a+LJHY8aMUf3nYu9fERERam9TFexL877Yl9r9spCxVr9SiYqKgojw609fJpOpNj9Om1L7Z2SvX2vXrlV7a2oUERGh+s/IXr/GjBmj9vbUiH1Z/Rf7Urtfte1LHsNBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrjwEFERESK48BBREREitP8wKGFTxwkcjT5+flqRyALlZWVwWg0qh2D6iAvLw+ZmZlqx6g1TQ4cSUlJmDVrFvz9/eHj44Phw4djz549asciCwUGBuLJJ59UOwaZ6fDhwxgyZAi8vb3RsGFDtGjRAk8//TRyc3PVjkY1WLVqFfr06YOGDRvCzc0NISEhWLJkCZ+saUxmZiZCQkLQr18/taPUmuYGjsLCQowcORJLly7FkCFDMH36dJw+fRojRozAvn371I5HZlq2bBnOnDmjdgwy06FDhxAeHo7ff/8dDz/8MObNm4fGjRvjiy++wODBg/ngZadWrFiByZMnIysrC7NmzcIzzzyD/Px8zJgxA++++67a8cgC06ZNQ3p6utox6sRZ7QCWeu2115CYmIgdO3Zg6NChAIBZs2aha9eumDp1Ks6dO6dyQrqdtLQ0vPXWWzh48CDi4+PVjkMWWLJkCQoLCxEXF4du3boBAN5++20MHjwYe/bswcaNGxEREaFySvqzhQsXIjAwEHFxcWjUqBEA4JVXXkH79u3x6aef4vXXX1c5IZnjs88+w86dO+Ht7a12lDrR3Cscy5Ytw1133VUxbABA8+bNMWTIECQnJyMuLk7FdFSTvLw8JCUloXHjxujRo4faccgCMTEx6NatW8WwUe6xxx4DABw4cECNWFSDnJwcnDhxAkOHDq0YNgDAz88P4eHhuH79OkpLS1VMSOY4efIkXnzxRSxYsAAtW7ZUO06daOoVjoyMDGRlZVWU3K2CgoIA3Hzpt1evXraORmbo1KkTfv75ZwDAmTNnEBgYqHIiMkdpaSmGDBmCnj17Vvmz1NRUAND8My9H5OzsjH379iEgIKDS5Tk5OTh27Bjuv/9+GAwGldKROYqKijBx4kT069cPM2fOxJdffql2pDrR1MCRmJgIANVOecHBwQCAq1ev2jQTkaMzGAxYvHhxlcuvXr2KTz/9FAaDAcOHD1chGdXEw8MDffv2rfj/RYsWISUlBdu3b4fRaMScOXNUTEfmmD17NtLT0/HDDz9Ap9OpHafONDVwlB9kWN2zqXbt2gEAsrOzbZqJqD7atm0bpk2bhmvXrmHRokUIDQ1VOxLdwWuvvYYbN24AALp06QJ3d3eVE1FNtm3bhiVLlmDTpk2a/1VKOU0dw+Hq6goAuH79epU/KygoAAA0adLEppmI6pOzZ89i5MiRGDFiBBo1aoRdu3Zh5syZasciMxQUFCApKQlLly5FZmYmevXqhcuXL6sdi6px6dIlPPbYY3jiiScwevRoteNYjaZe4WjRogUAVPtOlPIhxNfX16aZiOqLlStXYvr06dDpdHjvvfcwc+bMiicBZH9EBCICvf5/zysDAwMRGBgIvV6PqVOnYseOHXj88cdVTEnV+eyzz5CRkYGcnJxKxyxevHgRIoLHHnsMQUFBmvu1mKYGjqCgIOh0umoHjvK3WfKAUSLr27ZtG6ZMmYKwsDCsWbMGbdu2VTsS3cH8+fMxd+5cbN++HcOGDav0Z02bNgXwv4N+yb74+vqiW7duOH36dKXLi4uLYTKZcPTo0UqDpFZoauDw8/ND//79sW/fPpw9exYdOnQAcPMo+tWrV6NVq1bo3r27yimJHM/cuXPRuHFjbNiwwWF+n+zoyo+r+fHHH6sMHOXvdujatavNc9GdzZgxAzNmzKhyeffu3VFYWIgjR46okKruNDVwADeL78EHH8S4cePw2muvoUmTJliwYAHOnTuHbdu2OcSRvET2JCsrCydOnMDdd9+NhQsXVnudgQMH8p0qdmbYsGEIDQ3F4sWL4eXlhSFDhuDixYtYv349tm7dih49enDPyKY0N3Dcf//9iIyMxBNPPIExY8YAALy8vPDhhx9WOhkYEVnHr7/+ChHB4cOHcfjw4Wqvo9Pp+OBlZ/R6PTZv3oxJkybhzTffxJtvvlnxZw899BA++eQTODtr7iGANEyT/9omTJiAsWPH4tChQzCZTOjVqxecnJzUjkUW6NixI0RE7RhkhuHDh3OvNCogIAC//PILkpOTkZCQAHd3dwQHB6NVq1ZqR6Na+P3339WOUCeaHDiAm2fR6927t9oxiIjsml6vR4cOHSqOeSNSi/YOcyUiIiLN4cBBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrT/MBRXFysdgSqJe6dNpWVlcFoNKodg2qB9zntcoS9c67NX4qNjYWIWDtLraxevRrjx4+Hk5OT2lE0ISoqSu0IAACj0YioqChMnDhR7SgAgN9++03tCDVKS0uzm72Lj4+HXq9HaGio2lEA3PzZtG3bVu0Yt8W+1C57uc85Sl/WauD46KOParWYUr777ju1I2jG+PHj1Y5QyebNm9WOoAmxsbGIjY1VO4bdsueBg32pXexL69KJvYzetbB582aMHj0akyZNQmRkpNpxyAIPP/ww1qxZgy1btmDEiBFqxyEzFRUVoWnTphARZGRkwN3dXe1IZCb2pXY5SF+aNH0Mx+rVqwEAGzduRGFhocppyFw3btzAt99+CwBYtWqVymnIEtu3b8eNGzdQWFiInTt3qh2HLMC+1CZH6kvNDhwFBQXYunUrgJvPusr/m+zfd999V3EA1ObNm5Gfn69yIjJXZGQknJyc4OTkhJUrV6odh8zEvtQuR+pLzQ4c3377LUpKSgCA5acxK1euhF5/859eaWkpy08jcnNz8f3336OsrAxlZWXYunUrcnJy1I5FZmBfapcj9aVmB46VK1dCp9MBuPk2ve+//x7Xr19XORXdSVZWFn788ceKt1XqdDr+PlkjNm7ciLKysor/NxqNPABRI9iX2uRofanJgSMjIwO7d++udC4AEdH8Ebz1wYYNGyrtm9FoxK5du5CZmaliKjJHZGRkxYPWrZeRfWNfapej9aUmB47169dXuUxEWH4acLs92rhxo42TkCWuXr2Kn3/+uVL5mUwmREdH48qVKyomozthX2qXo/WlJgeOyMjIKifSMZlM+Pnnn5Genq5SKrqTS5cu4ddff4XJZKp0uYhgxYoVKqUic6xdu7bi98h/tmHDBhunIUuwL7XJEftScwNHamoqfvvttyqbANw8GKq6aZ7sw5o1a6p90DKZTIiJiUFaWpoKqcgcK1asqPZ05iaTSbPlVx+wL7XLEftScwPHmjVrbntaXqPRyPKzY7d70AIAZ2dnrFu3zsaJyBwpKSk4fPhwtafnFhEcPHgQ58+ft30wuiP2pXY5Yl9qbuCoaRNEBIcPH8bp06dtnIru5OzZszh27NhtP1OirKyM5WenVq5cCWfn238KgrOzM9auXWvDRGQu9qU2OWpfamrgSEhIwMmTJ2v8ICSDwWA3H7hD/7Nq1aoaH7REBMeOHcOpU6dsmIrMERkZidLS0tv+eWlpKZYvX27DRGQO9qV2OWpfamrgWLNmzR2vw/KzTytWrKjxQaucFl8mdGTHjx9HYmLiHa9X/uBG9oN9qV2O2pe1+rRYtVy5cgUDBgyodFlSUhL8/Pzg6elZcZmzszPS09Ph5+dn64hUjYsXL6Jdu3Zo3bp1xWV5eXm4fPkyAgMDK1336tWrto5HNTh+/DgGDRpU6aDDS5cuAQBatmxZcZler8fx48fRpUsXm2ek6rEvtcmR+1LTnxYrItDr9YiKikJERITaccgC69atw8SJE6s9ep7sW0REBPR6veaeXdV37EvtcpC+1PanxRIREZE2cOAgIiIixXHgICIiIsVx4CAiIiLFceAgIiIixXHgICIiIsVx4CAiIiLFceAgIiIixXHgICIiIsVx4CAiIiLFceAgIiIixXHgICIiIsVx4CAiIiLFceAgIiIixXHgICIiIsVx4CAiIiLFceAgIiIixXHgICIiIsVx4CAiIiLFceAgIiIixXHgICIiIsVx4CAiIiLFceAgIiIixXHgICIiIsVx4CAiIiLFceAgIiIixXHgICIiIsVx4CAiIiLFceAgIiIixXHgICIiIsVx4CAiIiLFOasdwBIlJSVIT09Hbm4uCgoKkJ+fj9DQUJw/fx779u2Dh4cHmjRpAh8fHzRu3FjtuHSLnJwcZGZmIisrCwUFBTh//jxCQ0Oxe/dueHp6wsPDAw0bNkSrVq1gMBjUjku3uHjxIvLy8lBQUICsrCwYDAbodDrs3r0bTZo0gYeHBxo1agQ/Pz+1o9It2Jfa5ah9qRMRUTtEddLS0hAdHY34+HgkJiYiMTERycnJKCsrM+vvt2jRAiEhIQgODkanTp0wYMAA3HXXXdDr+aKOkkwmE44ePYp9+/bh1KlTSExMREJCAq5cuWLW33d2dkb79u0r9q5r164IDw/ng5kNFBQUYP/+/YiLi0NCQgKSkpKQlJSE/Px8s/6+p6cngoODERQUhJCQEPTu3Rt9+/aFh4eHwsmJfalN9awvTXYzcBQVFWHHjh3YtWsXoqOjkZSUBFdXV4SGhlYUWHBwMPz9/dGoUSN4eHjA09MTXl5eyM/PR0FBAQoKCpCdnY0rV65UKsxjx44hMzMTPj4+GDBgAO6991489NBDaNGihdrftkNIT0/Hpk2bsHfvXvz888+4fv06mjZtitDQ0EoPQM2aNat4Rlz+lZ2dXbF/OTk5OH/+fMWdLikpCSdOnEBxcTGCg4MxaNAgDBkyBEOHDoWrq6va37ZDOHDgALZt24a9e/fiwIEDKC0tRWBgIDp16lSxd0FBQfDy8qq4v5UPEOX3t/z8fGRnZyMxMRFJSUlITEzEqVOncObMGbi4uKBnz54IDw/HyJEj0b17d5W/Y8fAvtSuetyXJoiKTCaT/PLLL/L0009LkyZNxMnJScLCwmTu3Lmye/duuXHjhtXWOXr0qHz00UcyYsQIadSokTg5OcmwYcNkzZo1VlunPikoKJBVq1bJAw88IE5OTtK4cWMZOXKkLFq0SI4dOyYmk8lq6+zatUvmzJkjvXr1EicnJ/H29pbp06dLTEyMVdaoby5cuCDvvvuuhISECAAJCAiQJ554QlavXi2XLl2y2jrp6emycuVKmTZtmvj7+wsA6dy5s8yfP19SU1Ottk59wb7ULvaliIgYVRk4SkpKZOnSpRWFFxoaKu+//75cvHjRJusXFhbK2rVr5cEHHxRnZ2dp3LixvPrqq3LlyhWbrK9lly5dktmzZ0ujRo3EYDDIiBEjJCoqSgoLC22yflpamixYsED+8pe/VDyALV++XEpKSmyyvpbFxsbKiBEjRK/XS9OmTeW5556TuLg4m67/7LPPio+Pj+j1ehk1apRN19cq9qV2sS8rse3AcePGDVmyZIm0a9dODAaDPPbYY3LkyBFbRqjiypUrMn/+fGnevLk0aNBAZs6cKRcuXFA1kz06f/68PPvss+Lm5iYtWrSQBQsWqF44hw8flqlTp4rBYBB/f3/5z3/+I0VFRapmske7d++W8PBwASBhYWGyceNGKS4uVi1PcXGxbNiwQXr16iUA5L777pOffvpJtTz2in2pXezLatlu4NiyZYv4+/uLq6urTJ48WU6fPm2rpc1SVFQky5cvlw4dOoiLi4u88sorNptC7dmNGzfkjTfeEDc3N2nXrp0sWrTI7l5SPX/+vMycOVPc3d0lICBAtm3bpnYku3D27FkZNmyYAJC+ffvKli1b1I5Uxf79+2X48OECQIYPHy7nzp1TO5JdYF9qE/uyRsoPHMnJyTJixAjR6XQyadIkSU9PV3rJOikuLpYPPvhAPD09JTAwUHbu3Kl2JNVs27ZNAgICpFGjRrJo0SK7/7VFWlqaTJgwQQDI6NGjJSUlRe1IqigsLJS33npL3NzcJDQ0VH7++We1I93R3r17pXPnztKgQQN55513VH0FRk3sS+1iX96RsgPHf//7X2nQoIF06tRJoqOjlVzK6lJTU2Xs2LECQKZMmSJ5eXlqR7KZ3NxcmThxogCQCRMm2Ox3xdaye/duCQ4OFg8PD/n666/VjmNTR44ckeDgYPH09JQPPvjA7kvvViUlJTJ//nzx8PCQzp07y/Hjx9WOZFPsS21iX5pNmYEjJydHxo8fL3q9Xl5//XVNld6fbdu2TXx9fSUkJESOHTumdhzFHT58WAIDA6V58+by/fffqx2n1oqLi2XOnDmi1+tl0qRJ9aIAP/vsM3Fzc5OBAwdq+l0gKSkp0q9fP3F3d5cvv/xS7TiKY19qF/vSItYfOI4ePVqxAT/++KO1b14VaWlp0r9/f3F3d5evvvpK7TiKKX/AGjRokN2/lGuunTt3iq+vrwQHBzvsM+a8vDwZN26c6PV6mTdvnpSVlakdqc5KS0srCvDhhx+WgoICtSMpgn2pXexLi1l34Ni7d680atRIBgwY4DAbUK68AHU6ncybN0/tOFZlMpnk1VdfFZ1OJ//85z8d4gHrVmlpafLXv/5VvLy8NHE8gyWuXbsmPXv2FF9fX4d5wLrVzp07xcfHR/r06SOZmZlqx7Eq9qU2sS9rzXoDx+bNm8XNzU1Gjx7t0EcrL1++XJydnWXq1KlSWlqqdpw6KysrkyeffFKcnJwc+tlIUVGRjBs3TlxdXWX9+vVqx7GKixcvSmhoqPj7+0tCQoLacRRz6tQpadu2rXTq1Mlh3oLJvtQm9mWdWGfg+Prrr8XJyUmeffZZMRqN1rhJu/bdd9+Ju7u7jBkzRtN3opKSEhk9erQ0aNCgXryVtKysTP7+97+Lk5OTLFu2TO04dZKUlCStW7eWu+66S3MHqdVGamqqdOnSRdq2bWt3bxG1FPtSm9iXdVb3gWPDhg3i5OQkr7/+ujUCacb+/fvFw8NDHn30UaudltaWTCaTTJo0STw9PeXXX39VO45NzZ07V5ycnGTz5s1qR6mVixcvir+/v/Tq1UuysrLUjmMz169flx49ekhAQIBVT8FuS+xL9qXWWLEv6zZwREdHi5ubm0yfPr2uQTRp9+7d4urqKrNnz1Y7isVefPFFMRgM9fZ98zNnzhQ3NzfNHdORnZ0t3bp1k8DAQNXPXKiGa9euSUhIiISGhsr169fVjmMR9iX7Uqus1Je1Hzji4+OlcePGMn78+HrxsuDtREZGik6nk48++kjtKGZ7//33Ra/Xy9q1a9WOopqysjIZM2aMeHl5yYkTJ9SOY5aioiLp16+ftGnTxmGOZaiN5ORk8fPzk4EDB2rmBGHsy5vYl9pkpb6s3cCRm5srgYGBmrrDK2n+/Pni7Ows+/btUzvKHUVHR4uTk5N8+OGHakdRXWFhofTt21dCQkI0cZ6OGTNmSKNGjeTkyZNqR1FdfHy8eHp6ygsvvKB2lDtiX1bGvtQmK/Rl7QaOSZMmSbNmzerFwWrmMJlMMnr0aGndurVcu3ZN7Ti3dfXqVfHz85OxY8eqHcVupKWlia+vr0yYMEHtKDXaunWr6HQ6WblypdpR7MaaNWtEp9PJt99+q3aUGrEvK2Nfalcd+9LygeO///2v6PV62bVrV20WdFhZWVnSvn17GTp0qF0eFGU0GmXIkCESEBAg2dnZasexK99//73o9XpZunSp2lGqlZKSIt7e3vL3v/9d7Sh25/HHH5cmTZpIcnKy2lGqxb6sHvtSu+rQl5YNHMnJydKgQYN6d4S1uWJjY8VgMMjnn3+udpQqlixZIi4uLnLw4EG1o9ilV155RTw9Pe3u2AiTySQDBw6Url27OvT5GmqroKBAunTpIvfdd5/aUapgX9aMfaldtexLywaOESNGSFBQkBQVFVmWrh558cUXxdvbW65evap2lAqXL18WLy8vmTt3rtpR7FZxcbEEBwfb3cunK1asEL1eL7/99pvaUezWgQMHRK/Xy7p169SOUgn78s7Yl9pUy740f+DYvHmzAJA9e/ZYnq4eyc3NlVatWsm0adPUjlLhkUcekbZt20p+fr7aUezarl27BIDdnNQnJydHWrZsKc8884zaUezetGnTpEWLFnbz8jf70jzsS+2qRV+aN3DcuHFD2rVrJ4888kjt09UjUVFRotPpJDY2Vu0o8tNPP4lOp9PsSa5sLSIiQjp27GgX7yZ47rnnpFmzZpo734QaMjIyxMfHR1588UW1o7AvLcS+1C4L+9K8gWPx4sXi7u7ucB8wpKT+/fvbxe+VBwwYYBc5tOLChQvi6uoqX3zxhao5UlNTxcXFxS5/v22vyntK7bOQsi8tx77UJgv78s4DR0lJibRr106ee+65uqerR8pfboqJiVEtQ2xsrADQ3Nk01fbUU09JQECAqp/7MGvWLGndurVdvNKiFYWFheLn5ycvv/yyahnYl7XDvtQuC/ryzgPH0qVLxWAwyPnz562Trh7p06ePjBo1SrX1hw4dKmFhYaqtr1Vnz54VZ2dn1c55kZGRIZ6envLxxx+rsr6Wvf/+++Lh4aHa+R3Yl7XHvtQmC/qy5oHDZDJJSEiIPP7449ZLV49s2bJFdDqdKmeGjI+PF51OJzt27LD52o5g8uTJ8pe//EWVtefNmyfNmjWTgoICVdbXsry8PPHx8ZG33nrL5muzL+uGfaldZvZlzQPHr7/+KgDkyJEj1ktWj5hMJgkICJCXXnrJ5mv/4x//kMDAQLs8qY4WHDx4UABIXFycTdc1Go3Spk0bmTNnjk3XdSSzZ8+W9u3b2/zfPvuybtiX2mVmXxr1qMGKFSvQpUsXdOvWraar0W3odDpMmjQJq1evhtFotNm6ZWVlWLt2LSZPngydTmezdR3JPffcg7/85S+IjIy06brR0dFITU3FlClTbLquI3n00UeRnJyM/fv323Rd9mXdsC+1y9y+vO3AUVRUhKioKEydOtXa2eqVyZMn49KlS9i9e7fN1ty5cyeuXLmCRx55xGZrOqKHH34Yq1evRnFxsc3WjIyMRM+ePRESEmKzNR1N+YO+LYdF9qV1sC+1y5y+vO3AsWPHDuTm5uLhhx9WJFx90bFjR/Tu3RurVq2y2ZqrVq1Cv379EBAQYLM1HdGkSZOQnZ2NXbt22WS9wsJCbNy4EZMnT7bJeo5sypQpWL9+PUpKSmyyHvvSOtiX2mVOX9524Ni1axd69uwJPz8/RcLVJyNHjsQPP/wAEVF8LRHB7t27MWrUKMXXcnRt2rTB3XffbbOBIyYmBvn5+RgxYoRN1nNkI0eORE5ODuLi4myyHvvSetiX2mROX9524Ni7dy/Cw8MVCVbfhIeH4+rVqzh16pTia8XHxyMjI4N7ZyXh4eGIjo62yVrR0dEIDAxEu3btbLKeI+vQoQP8/f2xd+9em6zHvrQe9qV23akvqx040tPTcfr0aQwaNEixYPVJ9+7d0aRJE5uUX3R0NHx8fHDXXXcpvlZ9EB4ejj/++AOXL19WfC0+aFnXoEGDbDIssi+ti32pXXfqy2oHjj179sDV1RV9+vRRNFx94eTkhP79+9uk/KKjozFw4EDo9TW+AYnM1K9fPxgMBsX3Lj8/H4cOHeKDlhWFh4cjNjYWN27cUHQd9qV1sS+16059We1POT4+HqGhoXB3d1c0nC3t2LEDa9euVW39nj174ujRo4qvEx8fj549eyq+ji2puXceHh7o3Lkz4uPjFV3njz/+QGlpKXr06KHoOrZkD/e5kpISJCQkKLoO+9L62Je1Z899We3AkZCQgODgYEWD2dp7772H2bNnq7Z+UFAQzp8/j6KiIsXWuHHjBtLS0rh3VhYUFITExERF10hISICrq6tDHb+h9r4FBATAYDDYZO94n7Mu9mXt2cPe3e4+V+3AkZiY6HCboLbg4GCYTCacPXtWsTWSkpJgMpm4d1YWHBys+INWYmIiAgMD4eTkpOg69YmzszMCAgJssne8z1kX+1K7aurLKgNHSUkJzp8/z02wsvIHEyXLLzExsaJkyXqCg4Nx9uxZlJWVKbYGH7SUofSwyL5UBvtSu2rqyyoDR3p6OsrKyuDv769ImJ9++gnPPvssgoKC0KZNG0ycOBH//e9/K53Kdvz48Xj33XcRExOD8ePHw9fXF126dMGCBQtgMpkq3Z4l1y33z3/+E/369cO5c+eq/Nmjjz6KIUOGWP3Bxc3NDc2bN0dKSopVb/dWqamp8PPzg4uLiyK3b829q82+AersXfv27VFSUqLoO1VSU1NVvc8Bjrt3Fy5csOpt3op9yb68HfZlNX35509XOXbsmACQU6dOWf0DXvbu3StOTk7i7e0tzz33nLz55pvSt29fASCzZ8+uuJ6Pj4906NBBGjduLH/7299k7ty5cs899wgAmTZtWqXbNPe6AwYMkNatW4uIyKpVqwSAzJ8/v9JtnT9/XgDI+PHjrf69i4iEhIQo+imW8+bNU+wTTq29d5bssdp7d/z4cQEgf/zxh9VvuyDZ5dQAACAASURBVJxS/zbM3TcR6+/drfsmos7ezZs3T0JDQ61+u+XYl+zL6rAvq+3Lqp8WW/6Jh2lpaVYP8uSTT4qrq6tkZWVVXFZYWCgtW7aUkJCQist8fHwEgHz44Yf/S2o0yqBBg0Sn08mhQ4csvu6tm5Cfny+enp5yzz33VMq3cOFCASBbt2617jf+/+vRo4ein4T4/PPPS1hYmCK3be29s2SP1d678junkp8c27p160o/C2sxd99ErL93fx441Ni79957T9q1a2f12y3HvmRfVod9WW1fVv202Pz8fACAp6enxS+l3MkLL7yAgwcPwsvLq+KykpISeHl5ITc3t9J1vby88I9//KPi//V6PebOnQsRqXLqVEuuC9x8687o0aNx6NAhnD9/vuLy9evXo2nTphgyZEhdv9VqNWzYEHl5eYrcNgDk5eWhYcOGity2Entn6b4B6uxd+c9U6b1T+z4HOObeKblv7Ev2ZXXYl9X3ZZWBo6CgoCKotYWEhMDPzw8LFy7E2LFjcc8996BNmzbVnsI2MDCwykcFd+nSBQCqHLlsyXXLTZo0CQCwYcMGADd/nxcXF4fx48fDYDDU4ru7M09Pz4qCUkJBQQEaNGigyG0rsXe12TfA9ntX/mCi9N6pfZ8DHHPvyjtNCexL9mV12JfV92WVgaP8ABolPpL7/fffR+vWrfF///d/KC0txeDBg7Fs2TL07du3ynVbtmxZ5bLyO7Wbm1utr1vu3nvvRYsWLSo2YcOGDRARRT+iuKio6LZ5rMHV1VWxT8dUYu9qs2+A7feu/FwASu+d2vc5wDH3ztXVVZHbBtiX7MvqsS+rz+T85wvKXw7Jz8+36tR+7do1vPrqq/D19cXp06crvZT1zjvvVLn+mTNnqlxW/pLQn9+CZsl1yzk5OWHChAn4+OOPkZqaivXr16NDhw4ICwsz91uymJIv4QE3J0sl3reu1N7VZt8A2+9d+UuDSu+dtZ/NWbpvgGPunZL7xr5kX/4Z+/L2fVnlFQ6lfl+dkpICk8mEhx56qFKQ1NTUak9hm5SUhNOnT1e67JtvvgEAdOvWrdbXvdWkSZMgIli0aBF+++03TJ482bJvykK2KD8lfuep1N7Vdt8A2+6dLQYOJfbO0n0DHHPvbDFwqL137EvLsS+VUWNf/vkw0tOnTwsAOXz4sFWPXM3NzRVPT0/x9vaWLVu2SFJSknzzzTfSunVradKkiTRq1EgSEhJE5OYRuTqdTjp37iybNm2SEydOyNtvvy16vV7GjRtX6XbNve6fj5gvFxISInq9XnQ6nZw7d86q3/OftWvXTt577z3Fbv/dd9+Vjh07Wv12ldg7S/ZY7b07cOCAAJDk5GTF1rj77rtlzpw5Vr1NS/ZNxPp7d7t9E7Hd3r300kvSo0cPxW6ffakc9qXD9WXVt8Xm5OQIANm+fbvVg0RFRYmnp6cAEADi7e0ty5cvlw0bNoiHh4c4OzuLyM0f7uDBg+XRRx8VvV5fcf2BAwdKRkZGpds097q324R//etfAkDuv/9+q3+/tzIajeLm5ibLli1TbI2vvvpKPDw8xGQyWf22rb13luyx2nv33XffiU6nk/z8fMXWeOCBB+TRRx+1+u2au28i1t+7mgYOW+3dI488IsOHD1fs9tmXymBfOmRfVh04RERatGihyDkBREQyMjLkxx9/lBMnTlTa6IyMDDl9+rSI3PzhPvDAAyIicv36ddm1a5ecPHmy2tuz5LrV2bRpkwCQjRs31vZbMsu5c+cEgPz222+KrbF//34BIKmpqYrcvjX3rq77JmK7vVuwYIG0adNG0TVmzpwpvXv3VuS2zdk3Ecfcu+7du8uLL76o6BrsS+tjX1ampftcDX1Z/cAxYMAAefrppxUNVZNbf7jWvG51HnzwQWnVqpWUlpbW+jbM8f333wsAyczMVGyNq1evCgDZvXu3Ymvcibn7Udd9E7Hd3j3++OMyePBgRdf49NNPpUmTJoqucSeOuHeNGjWSL774QtE12JfWx76s3fVqYgd9aazyLhXg5hGvSUlJZh4iok3vvPMOLl68iB07duCTTz6Bs3O1PwqrSUxMRLNmzeDt7a3YGr6+vvD29kZiYiLuvfdexdZRm633LikpCV27dlV0jeDgYGRlZeHatWvw9fVVdC012XLv0tPTkZubq/gHq7EvrY99aT321JfVrty5c2ds2rQJIlLlRCO20LJlSzRt2tTq173VF198gfz8fDzxxBN46qmnLP77ljp+/Dg6d+6s+DqdO3fGsWPHFF/ndszdj9ruG2DbvTOZTDh58iQmTJig6Drl/zbi4+MxePBgRde6HUfbu2PHjkGn06FTp06KrsO+tD72Ze2uVx276svqXvc4fPiwAJD4+HglX3mpV9q3by9vvPGG4uvMnTtXgoODFV+nvjh48KAAkOPHjyu+VmBgoLz++uuKr1NfvPzyy9K5c2fF12FfWh/7Upvu0JdVP0sFALp27YqmTZti7969Sg1C9UpKSgqSk5MxaNAgxdcaNGgQEhMTkZaWpvha9cHevXvRrFmzilMIK2nQoEG8z1nR3r17ER4ervg67EvrYl9q1536stqBQ6/Xo3///oiOjlY0XH2xe/duNGjQAL1791Z8rT59+sDV1ZV7ZyXR0dEIDw+3yUvlgwYNwoEDB6r9UDWyTHZ2No4cOWKTBy32pXWxL7XrTn1Z7cAB3Dz/+k8//YTCwkLFwtUXP/zwA/r27avoZzqUa9CgAcLCwrBz507F13J0BQUF2L9/v02eJQNAeHg4TCYTnylbwY8//ggAGDBggE3WY19aD/tSm8zpy9sOHGPGjMGNGzewdetWRcLVF7m5udi2bRvGjRtnszUjIiLw3XffKfrRzvXBt99+i+LiYowcOdIm6zVr1gwDBgzAqlWrbLKeI1u5ciUGDx4MHx8fm6zHvrQO9qV2mdOXtx04mjdvjvvuuw+RkZGKhKsvoqKiICIYO3aszdacMGECysrKsGnTJput6YgiIyMxbNgwNG/e3GZrTp48GVu2bEFmZqbN1nQ0mZmZ2Llzp+Kf9XEr9qV1sC+1y5y+vO3AAdwsv507d+Ly5ctWD1dfREZGYtSoUfDy8rLZmt7e3njwwQdZfnWQnp6OPXv22PRBC7j5bMvFxQXr16+36bqOZPXq1TAYDBg1apRN12Vf1h37UpvM7csaB46//e1v8PDwwLJly6yZrd44deoU9u/fb/MHLQCYMmUKoqOjq3y6IJln6dKlaNSoEUaMGGHTdT09PTFq1Ch8+eWXNl3XUYgIvvrqK0RERMDT09Oma7Mv64Z9qV1m9+Wd3lf7yiuvSPPmzeXGjRtWfseu45s8ebJ06tRJjEajzdcuKyuToKAgmTZtms3X1rr8/Hzx9fWVefPmqbL+kSNHRKfTyc6dO1VZX8vKPzjq999/V2V99mXtsS+1yYK+rP6zVG515coVadCggSxevNg66eqJs2fPirOzs0RGRqqW4euvvxaDwSDnz59XLYMWffDBB+Lh4SFXr15VLcMDDzwgYWFhqq2vVX369JFRo0aptj77snbYl9plQV/eeeAQEZkxY4a0adNGiouL656unnjqqackICBA8Q/KqUlJSYm0a9dOZsyYoVoGrSkqKhI/Pz+ZPXu2qjliYmIEgOzbt0/VHFqya9cuASAxMTGq5mBfWo59qU0W9qV5A8eFCxfEzc1NPvjgg7qlqydOnjwpBoNBvv76a7WjyH/+8x9xdXWVxMREtaNowjvvvCMeHh5y6dIltaPIoEGDpHfv3qq8xKw1ZWVl8v/+3/+r8ydqWgP70jLsS+2ysC/NGzhERN58801p0KABX24yQ3h4uHTv3l3KysrUjiJlZWXSrVs3ue+++9SOYvdSUlLEw8ND/v3vf6sdRURETpw4IQaDQfGPV3cEixcvFhcXF/njjz/UjiIi7EtLsC+1qRZ9af7AUVRUJMHBwRIREVG7dPVEZGSk6PV6+e2339SOUiEuLk70er2sW7dO7Sh2beTIkRIUFCRFRUVqR6nwwgsviLe3t6rHk9i7y5cvi5eXl8yZM0ftKBXYl+ZhX2pXLfrS/IFDRGTnzp0CQLZu3Wp5unogIyNDWrRoIdOnT1c7ShXTpk2TVq1ayfXr19WOYpe+/fZbASB79uxRO0olubm50qpVK5kyZYraUezWww8/LO3atZOCggK1o1TCvqwZ+1K7atmXlg0cIiJTpkwRX19fSUtLs/SvOjSTySQPPvigtGvXTrKystSOU0VGRoa0bt1aRo0aJSaTSe04diUlJUV8fHzs9i1xW7duFZ1Op+oR/PZq6dKlotfr7fYtxOzL6rEvtasOfWn5wJGfny+dOnWSfv36qXpEsb1ZsGCBODs7y6+//qp2lNuKjY0Vg8EgH330kdpR7EZpaan07dtXunTpYnfPkG/1/PPPi4eHh90co2APTpw4IQ0aNJBXX31V7Si3xb6sHvtSm+rYl5YPHCIi8fHx4u7uble/M1XTr7/+KgaDQd5//321o9zRu+++Ky4uLnb1O1M1zZ49Wzw8POTkyZNqR6lRcXGx9OrVS0JDQ+16MLKV/Px86dy5s/Tt29fuH8jZl5WxL7Wrjn1Zu4FDROSrr74SnU4nX331VW1vwiEkJiaKr6+vjBw5UhMvvRmNRhk6dKg0b95cTp8+rXYcVX3++eei0+lk+fLlakcxS3Jysvj4+Mjw4cPt/kFWSSUlJTJ06FBp1qyZXLhwQe04ZmFf3sS+1C4r9GXtBw4RkXnz5omTk5Ns3LixLjejWRcvXhR/f3/p2bOn5OXlqR3HbAUFBRIWFibt27eX9PR0teOo4rvvvhNnZ2d5++231Y5ikQMHDoinp6c88sgjmihsazOZTDJ16lRp0KCB6if4shT7kn2pVVbqy7oNHCI3zxDn7u5e786ImJWVJXfddZd06tRJMjIy1I5jsatXr0pQUJB069ZNsrOz1Y5jUz/99JO4ubnJM888o3aUWtmxY4cYDAbVz4aqhhdffFFcXFxk165dakepFfYl+1JrrNiXdR84ysrK5KGHHhIPDw/5/vvv63pzmnDx4kW56667pE2bNpKSkqJ2nFpLTk6WVq1aSbdu3ezizJq2sH37dmnQoIGMGzdO02fwLD9/wcyZMzX9fZjLaDTKc889J05OTrJ69Wq149Qa+5J9qSVW7su6DxwiN+9ETzzxhDg7O9vF6WmVdPbsWenYsaOEhIRo+s5TLjk5WYKDg6V9+/YOfzrfFStWiMFgkClTpjjEMRCbNm0SNzc3eeihh6SwsFDtOIopLi6WCRMmiKurq0OcjIl9qV3syzqxzsAhcvN3q7NnzxadTicLFixwyN8v//LLL+Lr6yu9evXS5MuCt3P16lW55557pHnz5g55NLbJZJJ//etfotPpZM6cOQ71b3P37t3SsGFDue+++xzyJEUZGRkSHh4ujRs3lujoaLXjWA37UrvYl7VmvYGj3EcffSTOzs4yatQohylAk8kk7733njg7O8vIkSMlPz9f7UhWl5eXJ0OHDhUXFxf58MMPHaYAMzIy5MEHHxRnZ2eH/cjwQ4cOSatWraRdu3YOVYC//PKLtGnTRtq0aSNHjx5VO44i2JfaxL6sFesPHCI3z0Xv7+8vbdq0sesTu5jj1g144403HPr35SaTSRYtWiQGg0FGjBghmZmZakeqkwMHDkj79u2lTZs28ssvv6gdR1HXrl2TYcOGOcS/01v/HQ4fPtyhnh1Xh32pTexLiykzcIjcLMDyf3gzZ86UnJwcpZZSzJYtW6R169b14gHrVnFxcdK+fXtp2bKlLF++XHPTe35+vrzxxhvi4uIiI0aMcPgHrHK3FmD//v3l+PHjakeyWEJCggwePLhePGDdin2pXexLsyk3cIjcLMDPP/9cvL29pVWrVpo54OvEiRMyYMAA0ev1Mn36dLs817/SMjMz5cknnxS9Xi/33nuvnDp1Su1IZlm9erW0bNlSmjZtKl9//bXm7vzWcPDgQbnnnnvEYDDIyy+/rImXtHNzc+WFF14QZ2dn6dWrlxw+fFjtSDbHvtQu9qVZlB04yl27dk0ef/xx0el00r9/f7t9D/3Zs2flqaeeEoPBIPfcc48cPHhQ7Uiqi42NlbvvvltcXFxk+vTpkpycrHakau3cuVP69u0rer1ennzyyXrzqsbtGI1G+fTTT6VJkybSqlUr+fjjj+XGjRtqx6qioKBAPvroI2nZsqV4e3vLF198UW9e1bgd9qV2sS9rZJuBo1xMTIzcd999AkB69eol3333nV08Az116pRMmTJFnJ2dJSAgQL766qt6X3q3Kisrk88//1z8/f3FYDDI1KlTJSEhQe1YYjKZZPPmzdKjRw8BIA888IDExcWpHcuuXLlyRWbOnCnu7u7SvHlzWbBggeTm5qodS3JycuTdd98VX19f8fDwkOeff16uXbumdiy7wr7UJvblbdl24Ch35MgRmTx5suj1emnTpo288sorNn9Pc3Z2tixfvlwGDx4sOp1OOnToIJ9//rlDnJ9BKUajUaKioqRTp04CQLp37y6LFi2y+asJ58+fl/nz50vHjh1Fp9PJ8OHDOWjcwdWrV+WNN94QLy8vcXd3l4iICNmyZYtN/70bjUbZv3+/PPXUU9KwYUNp2LChzJw5s96eLtpc7EttYl9Woc7AUe7kyZPy0ksviZ+fnwCQPn36yPz58+XAgQNSVlZm9fWSk5Pl66+/loiICHFzcxM3NzcZP368bN++nRO6BYxGo2zZsqXi5+ju7i7jx4+Xb775Rs6fP2/19crKyiQuLk7+/e9/S+/evQWAtGrVSl5++WV+XLuFrl+/LosXL5aePXsKAGndurU8//zzsm3bNkVe+cjJyZGtW7fKrFmzpFWrVgJAevfuLZ9++mm9O0V0XbEvtYl9WcGoExGByoxGI3bv3o1Vq1bhxx9/xOXLl+Hl5YUBAwagZ8+eCAoKQnBwMIKCguDq6lrp7yYmJiI4OLjSZSaTCSkpKUhKSkJiYiLi4+Px008/4dy5c3B3d8df//pXjBs3DhEREWjcuLEtv1WHk52djaioKERFRSEmJgaFhYXo0KEDBg4ciK5du1bsW9u2baHX6yv93er2rqioCElJSRV7FxcXh3379iEnJwctW7bE/fffj0ceeQTh4eFwcnKy5bfqcBISEhAZGYktW7bg5MmTcHJyQo8ePdCvXz+EhIQgJCQEQUFB8PHxqfT3MjIyoNPpqlyemZmJxMREJCQkICEhAfv378ehQ4dgNBoRGhqKkSNHYvLkyQgKCrLlt+lw2JfaVc/70mQXA8efnTx5Env37kV0dDTi4+ORkpICo9EIvV4PPz8/eHp6wtPTE15eXjh27Bg6deqEkpIS5Ofno6CgAOnp6SgqKgIA+Pr6okuXLujfvz/Cw8PRu3fvKndCso6ioiLExsYiOjoa+/btwx9//IFr164BANzc3Cr2zsPDAy4uLkhISEBoaCiys7ORn5+P/Px8pKenw2QywcnJCf7+/ujWrRsGDRqEQYMGoXPnzip/h47r6tWriI6ORnR0NOLi4pCYmIjCwkIAgI+PDxo3bowmTZrA09MTmZmZ0Ol08Pb2Rn5+PrKyspCdnY3r168DABo0aICgoCD07t0b4eHhGDhwIHx9fdX89hwa+1Kb6mFf2ufA8WfFxcU4ffo0EhMTkZKSUumOsmrVKoSFhaFnz54Vd6yWLVtWTIpNmjRRO369dv369Yrp+/LlyxV3lLi4OPz222945JFHKpViu3btEBwcjI4dO7LoVCQiuHDhAhITE3HmzBnk5uYiOzsbeXl5WL9+PXQ6HcaOHYuGDRvCy8sLjRo1QmBgYMWzM51Op/a3UG+xL7XLwfvSpOoxHHW1cOFCASA9e/ZUOwpZqHv37gJAFi1apHYUssCFCxdEp9OJTqeT1NRUteOQBdiX2uUgfWnU1zyQ2LeVK1cCAA4ePIiUlBSV05C5kpOTcfjwYQBAZGSkymnIEmvXroWTkxOcnJywbt06teOQBdiX2uRIfanZgePs2bM4evQoAMDZ2Rlr165VORGZa82aNXB2dgYA/P777zh9+rTKichcy5cvh9FohNFoxIoVK9SOQ2ZiX2qXI/WlZgeOVatWVWxCaWkpli9frnIiMteKFStQWloKADAYDIiKilI5EZkjISEBJ0+ehIhARHDs2DGcOnVK7VhkBvaldjlSX2p24IiMjKzYBAA4deoUTpw4oWIiMsexY8eQmJhY8f+lpaX45ptvVExE5lq9ejUMBkPF/7u4uPDXKhrBvtQmR+tLTQ4chw8fxpkzZypd5uLiwpcJNWDNmjWVHrSAmy/3xsfHq5SIzHXrMy0AKCkpwbJly9QLRGZhX2qXo/WlJgeONWvWwMXFpdJlJSUlWL58OcT+3+Vbb4kIVq5cWelBC7j5MuGaNWtUSkXmOHDgQLUHGqakpOD3339XIRGZi32pTY7Yl5obOEQEq1atQklJSZU/S0tLw4EDB1RIReaIjY1FWlpalctLS0uxYsUKlp8dq+6ZFqDt8qsP2Jfa5Yh9qbmBY//+/bh06VK1f+bi4sLys2PVPdMqd+nSJcTExNg4EZnDZDJh1apVVZ5pAf8rP6PRqEIyuhP2pXY5Yl9qbuCoaRNKSkqwcuVKlp8dMhqNWL16dbXPtAA+U7Zn0dHRFadcrs61a9ewf/9+GyYic7EvtclR+1JTA0dpaSnWrFlz200Abn6AVHR0tA1TkTl2795d8Vkb1SktLb3ts2hS1+rVq2/7oAXcLL/Vq1fbMBGZg32pXY7al5oaOHbt2oWcnJwar8Pys09/fktldbKzs7Fnzx4bJSJzlJSUYP369TU+aJWWlmLt2rU1Xodsj32pXY7al5oaOMx5G1dpaSk2btyI4uJiGyQicxQVFeHbb781axrX4suEjuz7779HXl7eHa+Xl5eHH374wQaJyFzsS21y5L50VjuAJSZOnIiRI0dW/L+IYPz48Xj++ecRFhZW6bo3btzQwqfn1Qs3btzA119/XemymJgYfPzxx1VOHOXh4WHLaHQH7du3r3Jmww8//BA6nQ7PP/98pcv9/f1tmIzuhH2pTY7cl5r4ePrbERHo9XpERUUhIiJC7ThkgXXr1mHixIkwmUxqRyELRUREQK/X8yyjGsO+1C4H6UuTpn6lQkRERNrEgYOIiIgUx4GDiIiIFMeBg4iIiBTHgYOIiIgUx4GDiIiIFMeBg4iIiBTHgYOIiIgUx4GDiIiIFMeBg4iIiBTHgYOIiIgUx4GDiIiIFMeBg4iIiBTHgYOIiIgUx4GDiIiIFMeBg4iIiBTHgYOIiIgUx4GDiIiIFMeBg4iIiBTHgYOIiIgUx4GDiIiIFMeBg4iIiBTHgYOIiIgUx4GDiIiIFMeBg4iIiBTHgYOIiIgUx4GDiIiIFMeBg4iIiBTHgYOIiIgUx4GDiIiIFMeBg4iIiBSnExGx5C+MGTNGqSy18sMPP6Bbt25o3ry52lEqvPTSSwgLC1M7RiUxMTFYuHCh2jEqXL58GfHx8RgyZIjaUSrodDps2LBB7RhVfPDBB4iNjVU7RoWjR49Cp9Oha9euakep0LdvX7zwwgtqx6iCfXln7Ms7c5C+NFk0cIgI9Ho9+vTpg9atW1uesB6IiopCVFQUIiIi1I5Sybp16zBhwgSMGzdO7Sh2KTU1FbGxsbBw/raJsWPH4sCBA3ZXyvYiJiYGYWFhiIqKUjtKJezLO2NfalMt+9LkXJvF/vGPf9jdPxB7ICJ2V3p/tm7dOrUj2KV169bZ1asIf9a7d2/u3W2MHTtW7Qg1Yl9Wj32pXbXtSx7DQURERIrjwEFERESK48BBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrjwEFERESK48BBREREiuPAQURERIrT/MBhMpnUjkBU7+Tn56sdgSxUVlYGo9Godgyqg7y8PGRmZqodo9Y0OXAkJSVh1qxZ8Pf3h4+PD4YPH449e/aoHYssFBgYiCeffFLtGGSmw4cPY8iQIfD29kbDhg3RokULPP3008jNzVU7GtVg1apV6NOnDxo2bAg3NzeEhIRgyZIlfLKmMZmZmQgJCUG/fv3UjlJrmhs4CgsLMXLkSCxduhRDhgzB9OnTcfr0aYwYMQL79u1TOx6ZadmyZThz5ozaMchMhw4dQnh4OH7//Xc8/PDDmDdvHho3bowvvvgCgwcP5oOXnVqxYgUmT56MrKwszJo1C8888wzy8/MxY8YMvPvuu2rHIwtMmzYN6enpaseoE2e1A1jqtddeQ2JiInbs2IGhQ4cCAGbNmoWuXbti6tSpOHfunMoJ6XbS0tLw1ltv4eDBg4iPj1c7DllgyZIlKCwsRFxcHLp16wYAePvttzF48GDs2bMHGzduREREhMop6c8WLlyIwMBAxMXFoVGjRgCAV155Be3bt8enn36K119/XeWEZI7PPvsMO3fuhLe3t9pR6kRzr3AsW7YMd911V8WwAQDNmzfHkCFDkJycjLi4OBXTUU3y8vKQlJSExo0bo0ePHmrHIQvExMSgW7duFcNGucceewwAcODAATViUQ1ycnJw4sQJDB06tGLYAAA/Pz+Eh4fj+vXrKC0tVTEhmePkyZN48cUXsWDBArRs2VLtOHWiqVc4MjIykJWVVVFytwoKCgJw86XfXr162ToamaFTp074+eefAQBnzpxBYGCgyonIHKWlpRgyZAh69uxZ5c9SU1MBQPPPvByRs7Mz9u3bh4CAgEqX5+Tk4NixY7j//vthMBhUSkfmKCoqwsSJE9GvXz/MnDkTX375pdqR6kRTA0diYiIAVDvlBQcHAwCuXr1q00xEjs5gMGDx4sVVLr969So+/fRTGAwGDB8+XIVkVBMPDw/07du34v8XLVqElJQUbN++HUajEXPmzFExHZlj9uzZe6rzuwAABERJREFUSE9Pxw8//ACdTqd2nDrT1MBRfpBhdc+m2rVrBwDIzs62aSai+mjbtm2YNm0arl27hkWLFiE0NFTtSHQHr732Gm7cuAEA6NKlC9zd3VVORDXZtm0blixZgk2bNmn+VynlNHUMh6urKwDg+vXrVf6soKAAANCkSRObZiKqT86ePYuRI0dixIgRaNSoEXbt2oWZM2eqHYvMUFBQgKSkJCxduhSZmZno1asXLl++rHYsqsalS5fw2GOP4YknnsDo0aPVjmM1mnqFo0WLFgBQ7TtRyocQX19fm2Yiqi9WrlyJ6dOnQ6fT4b333sPMmTMrngSQ/RERiAj0+v89rwwMDERgYCD0ej2mTp2KHTt24PHHH1cxJVXns88+Q0ZGBnJyciods3jx4kWICB577DEEBQVp7tdimho4goKCoNPpqh04yt9myQNGiaxv27ZtmDJlCsLCwrBmzRq0bdtW7Uh0B/Pnz8fcuXOxfft2DBs2rNKfNW3aFMD/Dvol++Lr64tu3brh9OnTlS4vLi6GyWTC0aNHKw2SWqGpgcPPzw/9+/fHvn37cPbsWXTo0AHAzaPoV69ejVatWqF79+4qpyRyPHPnzkXjxo2xYcMGh/l9sqMrP67mxx9/rDJwlL/boWvXrjbPRXc2Y8YMzJgxo8rl3bt3R2FhIY4cOaJCqrrT1MAB3Cy+Bx98EOPGjcNrr72GJk2aYMGCBTh37hy2bdvmEEfyEtmTrKwsnDhxAnfffTcWLlxY7XUGDhzId6rYmWHDhiE0NBSLFy+Gl5cXhgwZgosXL2L9+vXYunUrevTowT0jm9LcwHH//fcjMjISTzzxBMaMGQMA8PLywocffljpZGBEZB2//vorRASHDx/G4cOHq72OTqfjg5ed0ev12Lx5MyZNmoQ333wTb775ZsWfPfTQQ/jkk0/g7Ky5hwDSME3+a5swYQLGjh2LQ4cOwWQyoVevXnByclI7FlmgY8eOEBG1Y5AZhg8fzr3SqICAAPzyyy9ITk5GQkIC3N3dERwcjFatWqkdjWrh999/VztCnWhy4ABunkWvd+/eascgIrJrer0eHTp0qDjmjUgt2jvMlYiIiDSHAwcREREpjgMHERERKY4DBxERESmOAwcREREpjgMHERERKY4DBxERESmOAwcREREpjgMHERERKY4DBxERESmOAwcREREpjgMHERERKY4DBxERESmOAwcREREpjgMHERERKY4DBxERESnOuTZ/aeHChVi7dq21s5ANjBkzRu0IdiktLU3tCDWKiYnh3t1GXFwc+vTpo3aM22Jfahfvc9WrbV9aNHDodDqMGzeuVgvVF+PGjUObNm3UjlFF27ZtuXc18Pf3R/v27dWOUa2+ffvCyclJ7Rh2q2/fvggLC1M7RhXsyztjX2pTbftSJyKiQB4iIiKiciYew0FERESK48BBREREiuPAQURERIr7/wBvfwzI35CAaQAAAABJRU5ErkJggg==",
+                        "text/plain": [
+                            "<IPython.core.display.Image object>"
+                        ]
+                    },
+                    "execution_count": 16,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "q.visualize()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 17,
+            "id": "af533be3-e678-4e6d-9759-944127c448e9",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "CPU times: user 3.41 ms, sys: 2.13 ms, total: 5.54 ms\n",
+                        "Wall time: 2.01 s\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/plain": [
+                            "0     5\n",
+                            "1    13\n",
+                            "2    19\n",
+                            "3     3\n",
+                            "4    16\n",
+                            "5    17\n",
+                            "6    18\n",
+                            "7    17\n",
+                            "8    17\n",
+                            "9     5\n",
+                            "Name: a, dtype: int64"
+                        ]
+                    },
+                    "execution_count": 17,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "%%time\n",
+                "r = ddf.a.map(inc, meta=(None, 'int64'))\n",
+                "r.compute()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 18,
+            "id": "a27ea8bb-bd8c-4f9a-8f5f-f100f1ab6038",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAoYAAAISCAIAAADeH5l7AAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3dd1xUd77/8e8MM0PvoBTFSlFCxIolNiSyGsTERGOy9nr1Ku5vs64G48YkxmhyNa4l7jUbY9dEoyaisULEoKKIJRjpYhAsgHQpw8z5/TF7WZYgDJwzcz5n5v38Kwz6PR94+ciHKYCM4zgGAAAAYpOLPQAAAAAwhpUMAABABFYyAAAACQr+RyQlJWVnZ/M/hyAPD49hw4aJPUUroAUdaEEHWtCBFi3geJszZ44QHw5FYWFh/D8/xoQWdKAFHWhBB1o0T5gHriX3z0IfEv2ngxZ0oAUdaEEHWjQDzyUDAACQgJUMAABAAlYyAAAACVjJAAAAJGAlAwAAkICVDAAAQAJWMgAAAAlYyQAAACRgJQMAAJCAlQwAAEACVjIAAAAJWMkAAAAkYCUDAACQIL2VrNVqxR4BgJyKigqxRwDGGKurq9NoNGJPAf9WXl5eVFQk9hT6ksxKTk9PX7JkSefOnV1dXSMiIs6fPy/2RMB8fX3nzp0r9hRmLTk5OTw83MXFxd7e3sPDY/78+WVlZWIPZab27ds3ePBge3t7KyurgICALVu24P6D6IqKigICAoYOHSr2IPqSxkquqqqKjIzcsWNHeHj4ggULMjIyxo0bFx8fL/ZcZm3nzp2ZmZliT2HWkpKSQkNDr1+//vbbb69cudLR0XH79u1hYWHYBMa3e/fuqVOnFhcXL1myZOHChRUVFYsXL16zZo3Yc5m72bNn5+fniz1FKyjEHkAvK1asSEtLO3ny5JgxYxhjS5Ys6dWr14wZM7Kzs8Uezew8ePDggw8+uHbt2q1bt8Sexdxt2bKlqqoqMTExODiYMfbhhx+GhYWdP3/+u+++mzhxotjTmZf169f7+vomJiY6ODgwxpYtW9alS5etW7e+9957Yo9mvrZt23bq1CkXFxexB2kFadxL3rlz54svvqjbx4yx9u3bh4eH37t3LzExUdzBzFB5eXl6erqjo2P//v3FnsXcXbp0KTg4WLePdWbOnMkYu3r1qnhDmaPS0tKUlJQxY8bo9jFjzMvLKzQ09OnTp2q1WtzZzNadO3feeeeddevWeXp6ij1LK0jgXnJhYWFxcbHu/zX1/Pz8GGNJSUkhISEizWWmevToceHCBcZYZmamr6+v2OOYL7VaHR4ePmDAgIY35ubmMsakdbfABCgUivj4+K5du9bfUlpaevv27dGjRyuVShEHM1vV1dVvvfXW0KFDo6KivvzyS7HHaQUJrOS0tDTGWKOvdPz9/RljT548EWcmALEplcrNmzc3vOXJkydbt25VKpURERFiTWWebG1thwwZovvvjRs33r9//8SJExqN5t133xV3MLO1dOnS/Pz806dPy2QysWdpHQmsZN1riBp94d+pUyfGWElJiTgzARATExMze/bsgoKCjRs3BgUFiT2O+VqxYsWzZ88YY4GBgdbW1mKPY45iYmK2bNly5MgRaT1krSOB55ItLS0ZY0+fPm14Y2VlJWPM2dlZnJkAyMjKyoqMjBw3bpyDg8OZM2eioqLEnsisVVZWpqen79ixo6ioKCQk5NGjR2JPZF4ePnw4c+bMOXPmvPbaa2LP0hYSuJfs4eHBGGv04mrdhnZ3dxdnJgAa9u7du2DBAplM9umnn0ZFRem+fgUj4ziO4zi5/F/3cHx9fX19feVy+YwZM06ePDlr1ixxxzMr27ZtKywsLC0trX/5UV5eHsdxM2fO9PPzo/9UggRWsp+fn0wma7SSdd+Bg9d2gTmLiYmZNm3aoEGDDhw44OPjI/Y45mvt2rXR0dEnTpwYO3Zs/Y1ubm7s/15wB0bj7u4eHByckZFRf0tNTY1Wq71582b910yUSWAle3l5DRs2LD4+Pisrq1u3bowxtVq9f/9+b2/vvn37ij0dgGiio6MdHR0PHz4sxefMTInuyfuzZ882XMm6F/r26tVLtLHM0uLFixcvXtzwlr59+1ZVVd24cUOskVpFAiuZMRYdHf3KK69MmjRpxYoVzs7O69aty87OjomJkdyr6QCEUlxcnJKS0rt37/Xr1zd614gRI/Cia2MaO3ZsUFDQ5s2bnZycwsPD8/LyDh06dPz48f79+yMEtIo0VvLo0aP37NkzZ86c119/nTHm5OS0YcOG+p8cAmCGEhISOI5LTk5OTk5u9C6ZTIZNYExyufzYsWNTpkxZtWrVqlWrdDdOmDBh06ZNCoU0/h8LREjmn8vkyZPfeOONpKQkrVYbEhJiYWEh9kTmrnv37hzHiT2F+YqIiMDnn46uXbv+/PPP9+7dS01Ntba29vf39/b2FnsoYIyx69eviz1CK0hmJTPGFArFwIEDxZ4CAKAJcrm8W7duute7ALSNBF6BBgAAYA6wkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABKxkAAAAErCSAQAASMBKBgAAIAErGQAAgASsZAAAABKwkgEAAEjASgYAACBBYitZq9VWVFSIPQUwhhaUoAUdaEGHFFsoBDnl8ePH3377rSBHNS8lJaWwsHDEiBFGuNa9e/dkMpkRLiQstKADLehACzrQojkcb3PmzBFgDpLCwsL4f36MCS3oQAs60IIOtGiejOM4sT8QfdXW1rq5uVVWVubl5Xl4eIg9jllDCzrQgg60oEOiLaT0XPKpU6cqKipkMplxHvSAZqAFHWhBB1rQIdEWUlrJe/fuVSgUWq129+7dYs9i7tCCDrSgAy3okGgLyTxwXVlZ6ebmVl1drXszIyOje/fu4o5kttCCDrSgAy3okG4LydxLPnr0aG1tre6/lUrlN998I+485gwt6EALOtCCDum2kMxK3rt3r1z+r2nVavXOnTtFHcesoQUdaEEHWtAh3RbSeOD66dOn7du3r6ura3jjrVu3XnzxRbFGMltoQQda0IEWdEi6hTTuJX/77beNvnRQKpUHDhwQax5zhhZ0oAUdaEGHpFtI417ykCFDrly5otVqG97o6emZl5cnxR9eI2loQQda0IEWdEi6hQTuJefm5l6+fLnR55cx9vDhw0uXLokyktlCCzrQgg60oEPqLSSwkg8ePGhhYfH72yX0WITJQAs60IIOtKBD6i0k8MB1UFDQnTt3mpzTycmpoKBAoRDml2dAi9CCDrSgAy3okHoL6veSU1NTU1JS5HK58ncsLCxKSkrOnz8v9ozmAi3oQAs60IIOE2hB+usFxlh+fv68efPq30xOTn727NlLL71Uf0tZWZkYc5kjtKADLehACzpMoIUEHrhuaN68eTk5OWfOnBF7EEALQtCCDrSgQ4otqD9wDQAAYCawkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABKxkAAAAErCSAQAASMBKBgAAIAErGQAAgASsZAAAABKwkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABKxkAAAAErCSAQAASMBKBgAAIAErGQAAgASsZAAAABKwkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgQSH2AC2orq5OT0/Pz88vLy8vLS1NSUkpKiravn27s7Ozra2th4eHn5+fnZ2d2GOaBbSgAy3oQAs6TKCFjOM4sWf4D7W1tVevXo2Njb18+XJaWtr9+/e1Wq3uXY6OjtbW1jKZrLq6uri4uP6vdOzY0c/PLyQkZOTIkUOGDLG2thZpdlODFnSgBR1oQYfptaCykp89e3bkyJEDBw5cuHChsrKyU6dOw4YN69Gjh7+/v5+fX6dOnezt7Rv9lYqKivz8/NTU1LS0tNTU1J9//jk9Pd3S0nLw4MGTJ0+eNGmSk5OTKB+L1KEFHWhBB1rQYcotOLElJiZOnz7d3t5eqVSOHz/+yy+/zMzMbNtRubm5u3btmjx5srW1tZWV1cSJE8+dOyfstKYNLehACzrQgg6TbyHmSo6Li3v55ZcZY3369Nm0aVNBQYFQJ5eWln711VfDhg1jjIWEhPzwww9arVaow00SWtCBFnSgBR1m0kKclXz79u3hw4czxkaOHGnQL0wSExMjIyNlMlnv3r1//vlnw11IutCCDrSgAy3oMKsWxl7JZWVlf/7znxUKxcCBAxMSEoxz0Vu3boWHh8tkspkzZz558sQ4F6UPLehACzrQgg4zbGHUlXzhwoUOHTq4urpu375do9EY89Icxx06dKhDhw4uLi5Hjx418qUJQgs60IIOtKDDPFsYaSVrNJrVq1crFIpXX31VwOcAWqu8vHzOnDkymWzJkiU1NTVijSEutKADLehACzrMuYUxVnJpaWl4eLhKpfr73/9O4SUM+/bts7e379+//8OHD8WexdjQgg60oAMt6DDzFgZfyY8ePerTp4+np+e1a9cMfS39paam+vn5de3aNSMjQ+xZjAct6EALOtCCDrQw7ErOzs7u3r27r69vdna2QS/UBk+ePOnXr1/79u2vX78u9izGgBZ0oAUdaEEHWnAGXckPHjzo1KlTnz59Hj9+bLir8FFeXh4WFubi4pKSkiL2LIaFFnSgBR1oQQda6BjqB2qWlpYOHz5crVZfvHjRxcXFEJcQRFVVVXh4eHZ2dkJCQqdOncQexyDQgg60oAMt6ECLegZZydXV1WFhYbm5uQkJCR06dBD8fGEVFxcPHz68rq4uISHB2dlZ7HEEhhZ0oAUdaEEHWvwHQ9z1XrhwoaOj46+//mqIww3hwYMH3t7e48ePp/ACP2GhBR1oQQda0IEWDQm/kg8dOsQY279/v+AnG1R8fLxCodi4caPYgwgJLehACzrQgg60aETglZydne3o6Lhw4UJhjzWOjz/+WKVSkXrxPR9oQQda0IEWdKDF7wn8XPIrr7xy//79pKQkKysrAY81Dq1WGxYWVlJScu3aNQsLC7HH4Qst6EALOtCCDrRogoDr/bvvvpPJZLGxsQKeaWS6X2q9adMmsQfhCy3oQAs60IIOtGiSYCu5oqLCx8dn2rRpQh0olujoaEdHR0n/HDu0oAMt6EALOtDieQRbyZ9++qm9vT3Z7/LWX2VlZceOHaOiosQepO3Qgg60oAMt6ECL5xFmJVdVVXl6ei5btkyQ00S3adMmKyur/Px8sQdpC7SgAy3oQAs60KIZwqzkzZs3S/ffx+/p/sUsX75c7EHaAi3oQAs60IIOtGiGACtZq9V26dJl0aJF/I+iY926dQ4ODhUVFWIP0jpoQQda0IEWdKBF8wRYyXFxcYyx27dv8z+KjsLCQpVKtXfvXrEHaR20oAMt6EALOtCieQJ8X/Ls2bNv3bqVlJTE9/uxiBk/fnxNTc2pU6fEHqQV0IIOtKADLehAi+bJef79qqqqw4cPT5kyhec5BE2bNu3cuXP5+fliD6IvtKADLehACzrQokV8V3J8fHx5efmkSZN4nkNQRESEpaXljz/+KPYg+kILOtCCDrSgAy1axHclx8bG9ujRw8vLi+c5BFlaWg4ZMkT3zIckoAUdaEEHWtCBFi0SYCWHhobyPISskSNH6n7em9iD6AUt6EALOtCCDrRoEa+VXFZWduPGjREjRvA5hLJRo0Y9fPgwPT1d7EFahhZ0oAUdaEEHWuiD10q+e/euRqPp06cPn0Mo69Wrl4WFRUpKitiDtAwt6EALOtCCDrTQB6+VnJaWZmlp6ePjw+cQynQfXVpamtiDtAwt6EALOtCCDrTQB9+V7Ovr2+ZfFTl37tzp06dnZmbOmTOnY8eOoaGhe/fuZYxt2LChb9++7dq1GzNmTEZGRsO/8tNPP/33f/+3n59fx44d33rrrX/84x8ajUb3rjfffHPNmjWXLl1688033d3dAwMD161bp9Vq+XyAjDF/f3+p/HNHCyLQgg60oAMt9MLn54y8+eabr776apv/er9+/Tw8PLy8vHr27Dl16lSVSiWTycaMGaNQKCIjI1977TWVSuXj46PRaHR/PjY21sLCwsXFZdGiRatWrRoyZAhjbOnSpbr3urq6duvWzdHR8dVXX42Oju7Xrx9jbPbs2Xw+QI7jFi9ePHjwYJ6HGAFa0IEWdKAFHWihD14rOTw8fNasWW3+67rPwurVq3Vvnjx5kjFmbW2dlpamu2X69OmMsfo3586da2lpWVxcrHtT98O+AwICdG+6uroyxjZs2KB7U6PRjBw5UiaTJSUltXlCjuPef//9wMBAPicYB1rQgRZ0oAUdaKEPXg9cl5eX29vb8znBwsJi6dKluv/u1asXYyw0NNTPz093i+61eb/++qvuzT//+c/Xrl1zcnLSvVlbW+vk5FRWVlZ/mpOT05/+9Cfdf8vl8ujoaI7jzpw5w2dCe3v7hpcgCy3oQAs60IIOtNCHgs9f5v8p9vLyUqlUuv+2srLS3VL/Xt2zDrW1tbo3AwICioqK1q9ff/ny5ZycnIyMjLKysoZ/3tfXVyaT1b8ZGBjIGMvKyuIzob29fXl5OZ8TjAMt6EALOtCCDrTQB697ydXV1brPS5vZ2to2ukUuf+5In332WYcOHT766CO1Wh0WFrZz507d0wP1PD09f384zwltbGyePXvG5wTjQAs60IIOtKADLfTB616ytbV1VVUVnxP0V1BQsHz5cnd394yMjPovtT7++OOGfyYzM7Phmzk5OYwxf39/PtetrKz8/b8DgtCCDrSgAy3oQAt98LqXbMwHTO7fv6/VaidMmFD/+c3Nzb1582bDP5Oent7wRfBff/01Yyw4OJjPdfk/2GIcaEEHWtCBFnSghT4ks5L9/f3t7Oy++eab48ePZ2Rk7Ny5c/DgwQ4ODhUVFfXfB6bRaF599dWjR4/euXPno48+2rRp06RJk4YOHcrnuuXl5Q4ODkJ8BIaFFnSgBR1oQQda6IPXA9cuLi5FRUV8TtCfvb39jh07Zs2aFRkZqbv0559/bmtrO3369BdeeEGtVjPGRo0a5e3t/cYbb+i+43vEiBFffPEFz+sWFRXVv2aPMrSgAy3oQAs60EIvfL6DauXKlT169OBzQmsVFhaePXs2JSVFq9XW35KRkcFxnKur6x/+8AeO454+fXrmzJk7d+4IcsWXX3555syZghxlUGhBB1rQgRZ0oIU+eN1L9vf3z8rKqqurUyh4naM/V1fXsLCwRrfovum7nrOz88svvyzUFdPS0kaNGiXUaYaDFnSgBR1oQQda6IPXc8kBAQG1tbW6F6qZpKqqqgcPHvB8DZ5xoAUdaEEHWtCBFvrgu5KVSmVSUhKfQ4Ti6enp5uYm7JnXr1/XarVBQUHCHmsIaEEHWtCBFnSghT54PYBga2vbv3//uLi4yZMn8zlHEL/88ovgZ8bGxnbs2LFbt26Cnyw4tKADLehACzrQQh+87iUzxkJDQ2NjY3keQlZcXJwknqTRQQs60IIOtKADLVrEdyWPHDkyMzPTJJ8eqKysvHz58siRI8UeRF9oQQda0IEWdKBFi/iu5JdeesnNze3gwYM8zyHo6NGjWq127NixYg+iL7SgAy3oQAs60KJFfFeySqWaNGnS7t27eZ5D0J49e8aOHSv4SwAMBy3oQAs60IIOtGgZ/2+Ovnz5MmOM529+piYvL8/CwuLw4cNiD9I6aEEHWtCBFnSgRfP43ktmjA0cOLBHjx78fxQZKdu3b3dycoqIiBB7kNZBCzrQgg60oAMtWsB/q3Mc99VXXymVypycHEFOE11paamzs/MHH3wg9iBtgRZ0oAUdaEEHWjRDmJVcW1vbuXPnRYsWCXKa6D755BMHB4enT5+KPUhboAUdaEEHWtCBFs0QZiVzHLdlyxYrKysT+MKnpKSkXbt27777rtiDtB1a0IEWdKAFHWjxPIKt5JqamoCAgNdee02oA8WyaNEiV1fXwsJCsQdpO7SgAy3oQAs60OJ5BFvJHMedPXuWMXb8+HEBzzSyW7duKRSKnTt3ij0IX2hBB1rQgRZ0oEWTZBzHCfAisf8zefLka9eu3bx5097eXsBjjUOtVg8ZMsTS0jI+Pl4mk4k9Dl9oQQda0IEWdKBFEwRc7xzH5efnt2vX7q233hL2WONYunSpra3tr7/+KvYgwkALOtCCDrSgAy1+T+CVzHFcbGyshYXF9u3bBT/ZoE6ePCmTyUzg4aCG0IIOtKADLehAi0aEX8kcx61YscLa2joxMdEQhxtCenq6q6vrjBkzxB5EeGhBB1rQgRZ0oEVDBlnJarX6lVdecXNzS01NNcT5wsrPz+/ateuAAQMqKyvFnkV4aEEHWtCBFnSgRUMCv7yrXlVV1ejRo3NychISEnx8fAxxCUGUlZWNGDGivLw8ISGhXbt2Yo9jEGhBB1rQgRZ0oMW/GWLP6xQWFvbs2dPX1zc7O9twV+GjoKBgwIAB3t7eJvAd681DCzrQgg60oAMtdAy4kjmOe/ToUe/evT08PG7cuGHQC7VBTk6Ov79/586d09LSxJ7FGNCCDrSgAy3oQAvO0CuZ47jS0tKRI0c6OTmdOnXK0NfSX2JiopeXV3Bw8MOHD8WexXjQgg60oAMt6EALg69kjuOqq6v/+Mc/yuXy6OhotVpthCs2Q6vVbtiwQaVS/eEPfygpKRF3GONDCzrQgg60oMPMWxhjJets377d2tp66NChIj5V8OjRo/HjxysUijVr1mg0GrHGEB1a0IEWdKAFHWbbwngrmeO427dvBwYGWltbr169urq62piXrqur27Jli5OTk4+PT3x8vDEvTRNa0IEWdKAFHebZwqgrmeO42tratWvX2tra+vv7Hzt2TKvVGuGi586d69u3r1KpXLZsWUVFhRGuKAloQQda0IEWdJhhC2OvZJ379+9PnDhRJpMFBQXt37+/rq7OEFfRarUxMTGDBg1ijI0ePfrOnTuGuIrUoQUdaEEHWtBhVi3EWck6v/zyy9tvv21hYdG5c+eVK1emp6cLdfJvv/32ySef9OzZUyaTRUREXL58WaiTTRVa0IEWdKAFHWbSQsyVrJORkfGXv/zFy8uLMTZo0KCPP/740qVLzbzQ7nmPXWg0muTk5P/5n/8JDQ2Vy+Wurq4LFy68efOmwQY3QWhBB1rQgRZ0mHwLQ/1AzdbSaDTnz58/cODAmTNn8vPz7e3tBw8eHBgY6Ofn5+fn5+Pj4+zsbGdnl5ube+/ePd2PNCspKcnLy0tLS0tPT7979+6lS5eKiorc3d1DQ0MnT548duxYlUol9oclSWhBB1rQgRZ0mHALKiu5obS0tNjY2MuXL6empqanp5eWlta/y8LCgjGm0Wjqb7G1tfXz8/P39w8JCQkNDQ0KCjKB3+xNB1rQgRZ0oAUdJtaC4kpu5NGjR3l5eSUlJeXl5fPnzy8tLd21a5erq6uTk1O7du0o/4xy04MWdKAFHWhBh9RbKMQeoGUeHh4eHh6MsRs3bjx58oQxplKpwsLCxJ7LHKEFHWhBB1rQIfUWcrEHaIX9+/erVCqFQrFv3z6xZzF3aEEHWtCBFnRItIUEHrjW4TjO29v74cOHjDGlUllQUODo6Cj2UGYKLehACzrQgg7ptpDMveT4+Hjd55cxptFovv/+e3HnMWdoQQda0IEWdEi3hWRW8oEDBxq+SH3Pnj0iDmPm0IIOtKADLeiQbgtpPHCtVqvd3d0bvbo9Ly+vffv2Ik5lntCCDrSgAy3okHQLadxLPn36dMPPr87hw4dFGcbMoQUdaEEHWtAh6RbSWMn79+9XKpUNb9Fqtbt37xZrHnOGFnSgBR1oQYekW0jggetnz565urpWV1c3ul0mk2VnZ3fu3FmMocwUWtCBFnSgBR1SbyGBe8k//PBDTU3N729XKBQHDx40/jzmDC3oQAs60IIOqbeQwEreu3evXN7EnGq1eteuXcafx5yhBR1oQQda0CH1FtQfuC4uLm7Xrl1dXd3z/kBKSkpgYKAxRzJbaEEHWtCBFnSYQAvqP+P65MmTNjY2Wq1W96bud3rofr8HY0wulx8/fpz4p9hkoAUdaEEHWtBhAi2o30tuZN68eTk5OWfOnBF7EEALQtCCDrSgQ4otJPBcMgAAgDnASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABKxkAAAAErCSAQAASMBKBgAAIAErGQAAgASsZAAAABKwkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABKxkAAAAErCSAQAASMBKBgAAIAErGQAAgASsZAAAABKwkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABAX/IyorK6urq/mfo4/q6mq1Wl1UVGScy6lUKnt7e+NcSxBoQQda0IEWdKBFCzje5syZI8SHQ1FYWBj/z48xoQUdaEEHWtCBFs0T4F4yY6xPnz6ffvqpIEfRsWHDhtraWrGnaDW0oAMt6EALOtCiGcKsZBcXl1GjRglyFB0HDx7MyckRe4pWQws60IIOtKADLZqBl3cBAACQgJUMAABAAlYyAAAACVjJAAAAJGAlAwAAkICVDAAAQAJWMgAAAAlYyQAAACRgJQMAAJCAlQwAAEACVjIAAAAJWMkAAAAkYCUDAACQIL2VrNVqxR4BgJyKigqxRwDGGKurq9NoNGJPAf9WXl5eVFQk9hT6ksxKTk9PX7JkSefOnV1dXSMiIs6fPy/2RMB8fX3nzp0r9hRmLTk5OTw83MXFxd7e3sPDY/78+WVlZWIPZab27ds3ePBge3t7KyurgICALVu24P6D6IqKigICAoYOHSr2IPqSxkquqqqKjIzcsWNHeHj4ggULMjIyxo0bFx8fL/ZcZm3nzp2ZmZliT2HWkpKSQkNDr1+//vbbb69cudLR0XH79u1hYWHYBMa3e/fuqVOnFhcXL1myZOHChRUVFYsXL16zZo3Yc5m72bNn5+fniz1FKyjEHkAvK1asSEtLO3ny5JgxYxhjS5Ys6ToB8RgAACAASURBVNWr14wZM7Kzs8Uezew8ePDggw8+uHbt2q1bt8Sexdxt2bKlqqoqMTExODiYMfbhhx+GhYWdP3/+u+++mzhxotjTmZf169f7+vomJiY6ODgwxpYtW9alS5etW7e+9957Yo9mvrZt23bq1CkXFxexB2kFadxL3rlz54svvqjbx4yx9u3bh4eH37t3LzExUdzBzFB5eXl6erqjo2P//v3FnsXcXbp0KTg4WLePdWbOnMkYu3r1qnhDmaPS0tKUlJQxY8bo9jFjzMvLKzQ09OnTp2q1WtzZzNadO3feeeeddevWeXp6ij1LK0jgXnJhYWFxcbHu/zX1/Pz8GGNJSUkhISEizWWmevToceHCBcZYZmamr6+v2OOYL7VaHR4ePmDAgIY35ubmMsakdbfABCgUivj4+K5du9bfUlpaevv27dGjRyuVShEHM1vV1dVvvfXW0KFDo6KivvzyS7HHaQUJrOS0tDTGWKOvdPz9/RljT548EWcmALEplcrNmzc3vOXJkydbt25VKpURERFiTWWebG1thwwZovvvjRs33r9//8SJExqN5t133xV3MLO1dOnS/Pz806dPy2QysWdpHQmsZN1riBp94d+pUyfGWElJiTgzARATExMze/bsgoKCjRs3BgUFiT2O+VqxYsWzZ88YY4GBgdbW1mKPY45iYmK2bNly5MgRaT1krSOB55ItLS0ZY0+fPm14Y2VlJWPM2dlZnJkAyMjKyoqMjBw3bpyDg8OZM2eioqLEnsisVVZWpqen79ixo6ioKCQk5NGjR2JPZF4ePnw4c+bMOXPmvPbaa2LP0hYSuJfs4eHBGGv04mrdhnZ3dxdnJgAa9u7du2DBAplM9umnn0ZFRem+fgUj4ziO4zi5/F/3cHx9fX19feVy+YwZM06ePDlr1ixxxzMr27ZtKywsLC0trX/5UV5eHsdxM2fO9PPzo/9UggRWsp+fn0wma7SSdd+Bg9d2gTmLiYmZNm3aoEGDDhw44OPjI/Y45mvt2rXR0dEnTpwYO3Zs/Y1ubm7s/15wB0bj7u4eHByckZFRf0tNTY1Wq71582b910yUSWAle3l5DRs2LD4+Pisrq1u3bowxtVq9f/9+b2/vvn37ij0dgGiio6MdHR0PHz4sxefMTInuyfuzZ882XMm6F/r26tVLtLHM0uLFixcvXtzwlr59+1ZVVd24cUOskVpFAiuZMRYdHf3KK69MmjRpxYoVzs7O69aty87OjomJkdyr6QCEUlxcnJKS0rt37/Xr1zd614gRI/Cia2MaO3ZsUFDQ5s2bnZycwsPD8/LyDh06dPz48f79+yMEtIo0VvLo0aP37NkzZ86c119/nTHm5OS0YcOG+p8cAmCGEhISOI5LTk5OTk5u9C6ZTIZNYExyufzYsWNTpkxZtWrVqlWrdDdOmDBh06ZNCoU0/h8LREjmn8vkyZPfeOONpKQkrVYbEhJiYWEh9kTmrnv37hzHiT2F+YqIiMDnn46uXbv+/PPP9+7dS01Ntba29vf39/b2FnsoYIyx69eviz1CK0hmJTPGFArFwIEDxZ4CAKAJcrm8W7duute7ALSNBF6BBgAAYA6wkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABKxkAAAAErCSAQAASMBKBgAAIAErGQAAgASsZAAAABKwkgEAAEiQ2ErWarWVlZViTwGMoQUlaEEHWtAhxRbC/L5ktVpdVFQkyFHNu3TpUm5u7ptvvmmEa9XU1BjhKoJDCzrQgg60oAMtmsPxNmfOHGFGoScsLIz/58eY0IIOtKADLehAi+bJOI7jOUdqampeXp4gH1Lz6urqXn/99aqqqm+++cbZ2dkIV3R1dQ0ODjbChYSCFnSgBR1oQQdaNE+AB64DAgICAgL4n9OiEydOVFZWWlhYPH78+I033jDCFSUHLehACzrQgg60aJ6UXt61b98+pVKp1Wp3794t9izmDi3oQAs60IIOibYQ4IFr43j27Jmrq2t1dTVjTCaTZWdnd+7cWeyhzBRa0IEWdKAFHdJtIZl7yd9//339S9oUCsXBgwfFncecoQUdaEEHWtAh3RaSWcl79+6Vy/81rVqt3rVrl7jzmDO0oAMt6EALOqTbQhoPXBcXF7dv316tVje88ZdffnnhhRfEGslsoQUdaEEHWtAh6RbSuJd8+PBhjUbT8BaVSiWhxyJMCVrQgRZ0oAUdkm4hjXvJw4YNS0hI0Gq1DW/s0KHDb7/9JpPJxJrKPKEFHWhBB1rQIekWEriXnJ+f//vPL2PswYMHiYmJooxkttCCDrSgAy3okHoLCazkgwcP1j9R35BKpTpw4IDx5zFnaEEHWtCBFnRIvYUEHrgODg6+fft2k3M6Ozs/efJEoRDml2dAi9CCDrSgAy3okHoL6veSMzIybt269byvG4qLi3/66SfjTmS+0IIOtKADLegwgRakv15gjGVkZEycOLH+zezs7Jqamh49etTfYpyfYA4MLShBCzrQgg4TaCGBB64bmjdvXk5OzpkzZ8QeBNCCELSgAy3okGIL6g9cAwAAmAmsZAAAABKwkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABKxkAAAAErCSAQAASMBKBgAAIAErGQAAgASsZAAAABKwkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABKxkAAAAErCSAQAASMBKBgAAIAErGQAAgASsZAAAABKwkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgQcZxnNgzNKG4uDgtLS01NTUrK+vp06eVlZWVlZUlJSUPHjyoq6vr3Lmzg4ODra2tra2tq6tr586d/f39AwIC3N3dxR7cBKEFHWhBB1rQYUotqKzkioqKixcvxsXFJSYm3r17t6CggDFmZWXVvXt3V1dX3WfT2dnZ1tZWLpeXl5eXlpbqPu9FRUXZ2dkVFRWMMWdnZ39//wEDBowcOXL48OHOzs5if1iShBZ0oAUdaEGHCbcQeSVfvXr1hx9+iIuLu3r1al1dXWBg4EsvvdSzZ09/f39/f38fHx+5XK+H1h88eJCWlpaenn737t2EhISbN28yxnr37j1y5MiIiIihQ4fqeY45Qws60IIOtKDDLFpwYvjtt98+/vjjgIAAxli3bt3mzZt34MCBR48eCXV+UVHRkSNHFi9e3LNnT8ZYp06d3nvvvdTUVKHONyVoQQda0IEWdJhVC6OuZI1Gc+TIkdDQULlc7ubmtnjx4qtXrxr6oikpKcuWLevQoQNjbODAgTt37qytrTX0RelDCzrQgg60oMM8WxhpJavV6r179wYGBsrl8vHjx3///fdG/jg1Gs3Zs2enTJmiVCo7d+78xRdfVFVVGXMAOtCCDrSgAy3oMOcWBl/JdXV1X375Zbdu3RQKxZQpU+7cuWPoKzYvJydn4cKFVlZWnp6e69evN6t/9GhBB1rQgRZ0oIVhV/KVK1d69+6tUqnmzp2blZVl0Gu1Sn5+/jvvvGNra+vr63vq1CmxxzEGtKADLehACzrQgjPcSn769GlUVJSFhcXw4cNTUlIMdBWe8vLypk6dyhiLiIi4f/++2OMYClrQgRZ0oAUdaFHPICv54MGDbm5unp6e+/fvN8T5wvrxxx+7d+9uZ2e3ZcsWsWcRHlrQgRZ0oAUdaNGQwCu5qqpq/vz5Mpls4cKFpaWlwh5uOFVVVStXrrSwsJgwYUJxcbHY4wgDLehACzrQgg60+D0hV3JaWlpwcLCDg8M333wj4LFGc+HCBS8vLx8fn0uXLok9C19oQQda0IEWdKBFkwRbyd9++62dnd2AAQOys7OFOtP4Hj9+PHr0aJVKJekHiNCCDrSgAy3oQIvnEWYlb968WS6XL1q0qKamRpADRaTRaD788EOZTLZ8+XKtViv2OK2GFnSgBR1oQQdaNEOAlbx27VqZTPb+++/zP4qOPXv2KJXKadOmSevH6KAFHWhBB1rQgRbN47WS6+rq5s+fb2FhsX37dp5zEHT27Fl7e/uIiIjKykqxZ2kZWtCBFnSgBR1ooY+2r2StVjtjxgwbG5vjx4/zmYCyS5cuubi4jB49mvgDLGhBB1rQgRZ0oIWe2r6Sly5dqlQqT5482eYTJOHWrVtOTk6TJ0/WaDRiz/JcaEEHWtCBFnSghZ7auJI3b94sk8m+/vrrtv11aYmNjbW0tFy4cKHYgzQNLehACzrQgg600F9bVvLu3btlMtmGDRvadkkpOnjwoFwu/+STT8QepDG0oAMt6EALOtCiVVq9kpOSkiwtLZcuXdqGi0napk2bZDIZqQde0ELsQf4NLcQe5N/QQuxB/g0tWvsXW7eSy8vL/f39R4wYUVdX19ormYBp06a5uLgQ+eHvaIEWRKAFHWhBR9tatG4lv/322+3atcvPz2/V3zIZFRUVPXr0GDp0qFqtFnsWtEALKtCCDrSgo20tWrGSv/jiC7lcfubMmdbPZjp++eUXGxub6OhoccdACw4tKEELOtCCjja00HclZ2dnW1tbr1y5sk2DmZTt27fL5fIrV66INQBa1EMLOtCCDrSgo7UtZBzHMT1ERkZmZWXdvHlTqVTq8+dN26hRo0pKSq5evWphYWH8q6NFQ2hBB1rQgRZ0tK6FPnv76NGjjLHz58+3/UsF05KWlmZpaSnKb2JBi0bQgg60oAMt6GhVi5ZXcmVlZZcuXaZMmcJ7MJOybNkyBwcHI79yAS2ahBZ0oAUdaEGH/i1aXsnvvfeeo6Pjw4cPhRjMdFRUVPj4+MyYMcOYF0WLJqEFHWhBB1rQoX+LFlby06dPHRwcCP5EGAr27NmjUCgyMzONczm0aAZa0IEWdKAFHXq2aGElf/DBB46OjiUlJcINZjrq6up8fX3nzZtnnMuhRTPQgg60oAMt6NCzRXMruaKiws3NzcR+17Swtm/frlQqjfCzctCiRWhBB1rQgRZ06NOiuZX82Wef2draFhQUCD2Y6aitre3UqdOSJUsMfSG0aBFa0IEWdKAFHfq0eO5Krqur69Chw1/+8hcDDGZSNm3aZGNjU1paarhLoIWe0IIOtKADLehoscVzV/Lp06cZY6mpqYYZzHSUlJRYW1t/9dVXhrsEWugJLehACzrQgo4WWzz3p3dNnTo1Kyvr0qVLgvz4EtM2adKkgoKCuLg4A52PFvpDCzrQgg60oKOFFk0u6oqKCjs7uy+++MJQXyqYlh9++EEmk2VnZxvicLRoFbSgAy3oQAs6mm8hb3JPHzp0qLa2dtKkSQb8UsGEjBkzpl27dvv37zfE4WjRKmhBB1rQgRZ0NN+i6ZV8+PDhsWPHurq6GnIw06FQKCZOnHjo0CFDHI4WrYIWdKAFHWhBR/MtmljJdXV1Fy9eDA8PN/BgJmX06NG3b98uKCgQ9li0aAO0oAMt6EALOppp0cRKvnbtWllZWWhoqOEHMx0jRoywsLD46aefhD0WLdoALehACzrQgo5mWjSxkmNjY728vPz8/Aw+lwmxt7fv27ev4C9oRIs2QAs60IIOtKCjmRZNrOS4uLhRo0YZfipTExoaGhsbK+yZaNE2aEEHWtCBFnQ8r0XjlazRaC5fvjx8+HCjTGVSRowYkZaW9vjxY6EORIs2Qws60IIOtKDjeS0ar+ScnJxnz569+OKLxhrMdAQFBTHGUlNThToQLdoMLehACzrQgo7ntWi8ktPS0hhjvr6+xhlLT99///23334r9hQt8PT0dHR01H0CBYEWbYYWdKAFHWhBx/NaNF7Jqampnp6eTk5OxhqsaZcuXVq9enX9nfrVq1cvX768yXeR4ufnJ+A/d7TgAy3oQAs60IKOJls0cS/Z39/fWCM918WLF1euXPnw4UPdm4sWLfrrX//a5LtI8ff3F/BBIbTgAy3oQAs60IKOJlsoGr2dnp5O8OXs06dPF3sEvfj7++/atUuo09CCD7SgAy3oQAs6mmzR+F5yQUGBp6enINe7ffv2hAkTunTpMn78+F27dp07d27ixIlFRUX1f6CkpGThwoUvvPCCh4fHhAkTTp48qbt93rx5//jHPxhjs2bNioqKYoxFRUXNnDmzyXc1fxRjbO7cudOnT8/MzJwzZ07Hjh1DQ0P37t3LGNuwYUPfvn3btWs3ZsyYjIwMQT5kDw8PAX84DlrwgRbNHMXQgjGGFryhBR9Nt2j0ayh8fHw+++wz/r/s4sKFCzY2Nm5ublOmTJk+fbqdnV1AQABj7LffftP9gdzc3M6dO9va2i5YsGD58uW9e/eWy+Wff/45x3GfffbZoEGDGGNvvvnm3//+d47j+vXr16VLlybf1fxRur/r4eHh5eXVs2fPqVOnqlQqmUw2ZswYhUIRGRn52muvqVQqHx8fjUbD/6M+ePCghYWFVqvlfxSHFvygBVo0Dy34Qws+mmzReCW7uLhs27aN55U0Gk2vXr2cnZ1zcnJ0t9y+fVulUjX8FP/xj39kjF25ckX3Zk1NTWhoqEqlKioq4jhu7dq1jLEbN27o3lv/Kf79u1o8ql+/foyx1atX696r+4LI2to6LS1Nd4vuUY76N/mIiYlhjFVWVvI/ikMLftACLZqBFvyP4tCCnyZbNH7guqKiwt7evhX3vZty48aNW7duzZ8/v1OnTrpbgoKC3nzzzfo/8PTp0/379/fv3z8kJER3i0qlmjt3bm1t7ZEjR1p1LX2OsrCwWLp0qe6/e/XqxRgLDQ2tfwpkxIgRjLFff/21TR/rf9B96srLy/kfxdCCH7RAi2agBf+jGFrw02SL/3h5V01NTW1trZ2dHc8rZWVlMcYavRIvMDCw/r91X2JUVFQ0/LyXlZXV/1396XOUl5eX7msuxpiVlZXulvo/bGFhwRirra1t1XWbVP8pbt++Pc+j0IIntECLZqAFWjzvKHFb/MdK1l3G0tKS55WKi4sZY41+faZGo6n/b92T9paWlkqlsv5GV1fXP/7xjw1L6EOfo2xtbRv9Lbm86V8UzZPuU1ddXc3/KLTgCS1aPAot0IIPtOCpyRb/sZJtbGxkMlllZSXPK3Xu3JkxlpCQMG7cuPobb9y4Uf/fXbt2ZYz5+vrqXsymo9FoysvLbWxsWnUtAY/iT/ep4/9lI0ML3tBCqKP4QwuhjuIPLYQ6ir8mW/zH8rewsLC2tub/NMMLL7ygUCjOnj1bf0t2dva5c+fq3+zevbu7u/vp06fVanX9jZ988omzs/PVq1dbdS0Bj+JP96nj/+QKQwve0AItmoEW/I9CC56abNH4/ridnV1FRQXPK3l7ey9ZsiQ5OXnGjBk//vjjpk2bxowZ0/APqFSqTz75pKysbMqUKcnJyZmZmevXr1+9evXLL788ZMgQxpjuef7t27dfu3at0eGN3tXiUcYk4D93hhb8oAVaNAMtBDkNLfhoukWjl2V369ZtzZo1/F/erVarP/roI93TA66urlFRUX/7298YYyUlJfV/ZtOmTbonzxljCoXiv/7rv3QvQ+c4rrCwcODAgYyxESNGcP/5ovZG72rxqH79+gUEBNT/Sd1zCfPnz6+/Zffu3Yyxb775hv9HvWfPHpVKxf8cHbTgAy2aPwot0II/tOCjyRaNV3Lv3r2XL1/O/2L1nj59qvuPRYsWde7cudF7y8rKLly4cOLEifrvP2soLy+vrKysyWN//67mjzKOrVu3urm5CXUaWvCBFvocZRxooc9RxoEW+hxlHE22aPwzrjt27JiTk9PyXe5mVVVVhYaGDhw48PPPP3d2dmaMVVZWnj59Ojg4uNGftLe3HzZs2PPOafjS8xbf1fxRxnHv3j0fHx+hTkMLPtBCn6OMAy30Oco40EKfo4yjyRaNV7K/v3/D59Xbxtra2sXFZfPmzaWlpREREcXFxV9//XVeXt4///lPnicTJ+zvRUELPtCCDrSgAy3oaLpFo3vN//znP21tbfn/BNSSkpK//vWvvXv3lslkdnZ2w4YNO3/+PM8z6fPz81u1apVQp6EFH2hBB1rQgRZ0NNmi8Uq+ePEiYyw3N1eoq5aUlAjyE7rpq62tVSqVBw4cEOpAtGgztKADLehACzqe16LxN0Hpfv+GgL/j2tHR0UA/+oSa7OxstVot4INCaNFmaEEHWtCBFnQ8r0XjD97Nzc3b2/v3390FLbp69aqlpaXu36gg0KLN0IIOtKADLeh4Xosmvh4ZMWJEXFycUaYyKbGxsYMGDbK2thbwTLRoG7SgAy3oQAs6nteiiZU8cuTIhISEmpoaowxmOuLi4kaOHCnsmWjRNmhBB1rQgRZ0PK9FEys5LCzs2bNnV65cMfxUpiMzM/P+/fuhoaHCHosWbYAWdKAFHWhBRzMtmljJnTp16tKlCx6LaJXY2FgbG5sBAwYIeyxatAFa0IEWdKAFHc20aPq1beHh4ceOHTPwVCblhx9+CA0Nrf/F1wJCi9ZCCzrQgg60oKO5Fk1+y1R8fDxj7NatW4b/7ixT8PjxY2G/268htGgVtKADLehACzqab9H0veSXXnqpW7due/bsMdhXCSZl//791tbWkZGRhjgcLVoFLehACzrQgo7mWzS9kmUy2ZQpU/bt26fRaAw5m4nYs2fPG2+8YWNjY4jD0aJV0IIOtKADLehoocXz7lxnZGTIZLIff/zRYHffTcSdO3cYY3FxcYa7BFroCS3oQAs60IKOFlvIOI573jIfOXKklZXVjz/+aIAvFEzHvHnz4uLi0tLSDPpz4NBCH2hBB1rQgRZ0tNyimX1++vRpxtjVq1cF/0rBZOTm5qpUqi+//NLQF0KLFqEFHWhBB1rQoU+L5u4lM8YGDBjQoUOHI0eOCP21gomIioo6duxYZmamIb61oBG0aB5a0IEWdKAFHXq1aH6rHz16VCaT3b59W8gvFUzFo0ePrK2tN2/ebJzLoUUz0IIOtKADLejQs0ULK1mr1QYFBU2cOFG4wUzH//t//8/Dw+PZs2fGuRxaNAMt6EALOtCCDj1btLCSOY47fvw4Y+zcuXMCDWYiUlJSlErltm3bjHlRtGgSWtCBFnSgBR36t2jhuWSd8ePH371795dffrG0tBToQXVp4zhu1KhRZWVliYmJFhYWxrw0WjSCFnSgBR1oQUfrWuiz4e/fv29ra7tmzRoeXyWYlN27d8vl8itXrhj/0mjRCFrQgRZ0oAUdrWqh10rmOG7NmjU2Njb37t1r+1ymori4uH379gsWLBBrALSohxZ0oAUdaEFHa1vo9cA1Y6y2trZPnz5OTk4//fSTQqEQ4M68ZE2cODEhIeHOnTvOzs6iDIAW9dCCDrSgAy3oaHUL/bd9SkqKjY3N8uXL2/KlgqnYvHmzXC4/e/asuGOgBYcWlKAFHWhBRxtatGIlcxz31VdfyWSyH374oZWDmYhbt25ZW1t/8MEHYg/CcWiBFmSgBR1oQUfbWrRuJXMcN3XqVHd39wcPHrT2L0pdSUlJ9+7dR40apdFoxJ7lX9ACLUSHFnSgBR1tbqHvc8n1KioqQkJCVCrVTz/95Ojo2JYH1yWotrb2lVdeuXPnTnJysoeHh9jj/AtaoIW40IIOtKCDV4s27P/c3NyOHTsOHz68qqqqDX9dcrRa7dSpUx0cHJKTk8WepTG0oAMt6EALOtCiVdqykjmOS0lJcXZ2joyMVKvVbTtBQv70pz+pVKozZ86IPUjT0IIOtKADLehAC/21cSVzHBcfH29lZTVv3jw6z1sYwkcffWRhYXHo0CGxB2kOWtCBFnSgBR1ooae2r2SO444dO6ZSqd5+++3a2lo+59Ck1Wr/8pe/yOXyf/zjH2LP0jK0oAMt6EALOtBCH7xWMsdxsbGxDg4Ouh/gyfMoUtRq9ezZs1Uq1b59+8SeRV9oQQda0IEWdKBFi/iuZI7jkpKS2rVr169fvydPnvA/jYKKioqxY8fa2tqePHlS7FlaBy3oQAs60IIOtGieACuZ47j09PQuXbp07dr12rVrghwoorS0tF69erm7u1+9elXsWdoCLehACzrQgg60aIYwK5njuMePH48ePVqlUm3cuFGr1Qp1rJHt27fP3t6+f//+2dnZYs/SdmhBB1rQgRZ0oMXzCLaSOY7TarUbN25UKpWRkZFFRUUCnmwEVVVVUVFRjLF58+bV1NSIPQ5faEEHWtCBFnSgRZOEXMk6Fy5c8Pb27tChw+HDhwU/3EDOnz8fEBDg7Ox89OhRsWcRElrQgRZ0oAUdaNGI8CuZ47iCgoIZM2bIZLI//OEPGRkZhriEUPLz89966y3GWGRk5P3798UeR3hoQQda0IEWdKBFQwZZyToXL14MCgqysrJ6//33y8vLDXehtqmurt6wYYODg0OXLl1M/neVoAUdaEEHWtCBFjoGXMkcx6nV6vXr19vb27u6un744YfFxcUGvZyeKisrN27c6O3tbWlp+d577z179kzsiYwBLehACzrQgg604Ay9knUKCwv/9re/OTs7Ozg4REdHi/jtaGVlZWvXrm3Xrp2Njc2f/vQnM/yVYWhBB1rQgRZ0mHkLY6xknfLy8o0bN3p6elpaWkZERHz77bdGe9GgRqO5ePHivHnz7O3t7ezsoqKi8vPzjXNpmtCCDrSgAy3oMNsWxlvJOpWVlV9//fXIkSPlcrmbm9uiRYsuXrxooF8PUldXd+3atb/+9a/e3t6MsZCQkC1bthB5MIQCtKADLehACzrMsIWxV3K9Bw8ebNy4MTg4mDFmY2MTFha2du3aixcv8v+J5FlZWf/7v/87ceJEFxcXxliHDh2WLVuWmpoqyNgmCS3oQAs60IIO82kh4ziOiSo9PT0uLi42Nvann3568uSJvb29v7+/n59fjx49/Pz8/P39nZycHBwcHBwcLCwsysvLCwsLu3TpwnFcSUlJRUVFaWlpenp6enp6WlpaampqWlpaIUwQwQAACs1JREFUcXGxk5PT8OHDQ0NDQ0NDAwMDZTKZuB+jVKAFHWhBB1rQYfItxF/J9TiOS0lJuXLlSv0nKycnp66urv4PWFtbKxQK3ZcSlZWV9bfL5XIfHx9/f39/f/+AgIB+/fr16dPHwsJCjA/CRKAFHWhBB1rQYaotCK3k36utrc3KyiovLy8rKystLa2oqFi7dm1RUdG6devs7OycnZ3t7Ozs7Oy6detmbW0t9rAmDi3oQAs60IIO02hBeiU3UlBQ4OnpqdFokpOTe/fuLfY4Zg0t6EALOtCCDom2kIs9QCscOnSIMaZUKg8cOCD2LOYOLehACzrQgg6JtpDSveSQkJCkpCStVuvh4ZGXlyeXS+nrCRODFnSgBR1oQYdEW0hjSsbYb7/9du3aNa1Wyxh79OjRzz//LPZE5gst6EALOtCCDum2kMxK3r9/f/2L4pRK5f79+8Wdx5yhBR1oQQda0CHdFpJ54Lpnz553796tf9PBwaGgoEClUok4ktlCCzrQgg60oEO6LaRxL/nu3bsNP7+MsbKysnPnzok1jzlDCzrQgg60oEPSLaSxkvft26dUKhveolQq9+3bJ9Y85gwt6EALOtCCDkm3kMYD1506dfrtt98a3WhlZVVYWGhrayvKSGYLLehACzrQgg5Jt5DAveQrV678/vPLGKupqYmJiTH+POYMLehACzrQgg6pt5DASj5w4ECTT8vL5fK9e/cafx5zhhZ0oAUdaEGH1FtQf+Bao9F4eHgUFhY2+V6lUvn48WNnZ2cjT2We0IIOtKADLegwgRbU7yXHxcU97/PLGFOr1d99950x5zFnaEEHWtCBFnSYQAuF2AO0oFu3bmfPnq1/8/PPP3/8+PHatWvrb/Hy8hJjLnOEFnSgBR1oQYcJtKD+wHUj8+bNy8nJOXPmjNiDAFoQghZ0oAUdUmxB/YFrAAAAM4GVDAAAQAJWMgAAAAlYyQAAACRgJQMAAJCAlQwAAEACVjIAAAAJWMkAAAAkYCUDAACQgJUMAABAAlYyAAAACVjJAAAAJGAlAwAAkICVDAAAQAJWMgAAAAlYyQAAACRgJQMAAJCAlQwAAEACVjIAAAAJWMkAAAAkYCUDAACQgJUMAABAAlYyAAAACVjJAAAAJGAlAwAAkICVDAAAQAJWMgAAAAlYyQAAACRgJQMAAJCAlQwAAEACVjIAAAAJMo7jeB6xa9euCxcuCDJNi7KysqqrqwMDA41zucDAwHfeecc41xIEWtCBFnSgBR1o0TwBVvLcuXOPHj3ar18/nudQc+fOnYCAgLNnz4o9SCugBR1oQQda0IEWzVMIMk3v3r1PnTolyFF0zJ07NycnR+wpWg0t6EALOtCCDrRoBp5LBgAAIAErGQAAgASsZAAAABKwkgEAAEjASgYAACABKxkAAIAErGQAAAASsJIBAABIwEoGAAAgASsZAACABKxkAAAAErCSAQAASMBKBgAAIEF6K1mr1Yo9AgA5FRUVYo8AjDFWV1en0WjEngL+rby8vKioSOwp9CWZlZyenr5kyZLOnTu7urpGREScP39e7ImA+fr6zp07V+wpzFpycnJ4eLiLi4u9vb2Hh8f8+fPLysrEHspM7du3b/Dgwfb29lZWVgEBAVu2bMH9B9EVFRUFBAQMHTpU7EH0JY2VXFVVFRkZuWPHjvDw8AULFmRkZIwbNy4+Pl7suczazp07MzMzxZ7CrCUlJYWGhl6/fv3tt99euXKlo6Pj9u3bw8LCsAmMb/fu3VOnTi0uLl6yZMnChQsrKioWL168Zs0asecyd7Nnz87Pzxd7ilZQiD2AXlasWJGWlnby5MkxY8YwxpYsWdKrV68ZM2ZkZ2eLPZrZefDgwQcffHDt2rVbt26JPYu527JlS1VVVWJiYnBwMGPsww8/DAsLO3/+/HfffTdx4kSxpzMv69ev9/X1TUxMdHBwYIwtW7asS5cuW7dufe+998QezXxt27bt1KlTLi4uYg/SCtK4l7xz584XX3xRt48ZY+3btw8PD793715iYqK4g5mh8vLy9PR0R0fH/v37iz2Lubt06VJwcLBuH+vMnDmTMXb16lXxhjJHpaWlKSkpY8aM0e1jxpiXl1doaOjTp0/VarW4s5mtO3fuvPPOO+vWrfP09BR7llaQwL3kwsLC4uJi3f9r6vn5+THGkpKSQkJCRJrLTPXo0ePChQuMsczMTF9fX7HHMV9qtTo8PHzAgAENb8zNzWWMSetugQlQKBTx8fFdu3atv6W0tPT27dujR49WKpUiDma2qqur33rrraFDh0ZFRX355Zdij9MKEljJaWlpjLFGX+n4+/szxp48eSLOTABiUyqVmzdvbnjLkydPtm7dqlQqIyIixJrKPNna2g4ZMkT33xs3brx///6JEyc0Gs27774r7mBma+nSpfn5+adPn5bJZGLP0joSWMm61xA1+sK/U6dOjLGSkhJxZgIgJiYmZvbs2QUFBRs3bgwKChJ7HPO1YsWKZ8+eMcYCAwOtra3FHsccxcTEbNmy5ciRI9J6yFpHAs8lW1paMsaePn3a8MbKykrGmLOzszgzAZCRlZUVGRk5btw4BweHM2fOREVFiT2RWausrExPT9+xY0dRUVFISMijR4/Ensi8PHz4cObMmXPmzHnttdfEnqUtJHAv2cPDgzHW6MXVug3t7u4uzkwANOzdu3fBggUymezTTz+NiorSff0KRsZxHMdxcvm/7uH4+vr6+vrK5fIZM2acPHly1qxZ4o5nVrZt21ZYWFhaWlr/8qO8vDyO42bOnOnn50f/qQQJrGQ/Pz+ZTNZoJeu+Awev7QJzFhMTM23atEGDBh04cMDHx0fscczX2rVro6OjT5w4MXbs2Pob3dzc2P+94A6Mxt3dPTg4OCMjo/6WmpoarVZ78+bN+q+ZKJPASvby8ho2bFh8fHxWVla3bt0YY2q1ev/+/d7e3n379hV7OgDRREdHOzo6Hj58WIrPmZkS3ZP3Z8+ebbiSdS/07dWrl2hjmaXFixcvXry44S19+/atqqq6ceOGWCO1igRWMmMsOjr6lVdemTRp0ooVK5ydndetW5ednR0TEyO5V9MBCKW4uDglJaV3797r169v9K4RI0bgRdfGNHbs2KCgoM2bNzs5OYWHh+fl5R06dOj48eP9+/dHCGgVaazk0aNH79mzZ86cOa+//jpjzMnJacOGDfU/OQTADCUkJHAcl5ycnJyc3OhdMpkMm8CY5HL5sWPHpkyZsmrVqlWrVulunDBhwqZNmxQKafw/FoiQzD+XyZMnv/HGG0lJSVqtNiQkxMLCQuyJzF337t05jhN7CvMVERGBzz8dXbt2/fnnn+/du5eammptbe3v7+/t7S32UMAYY9evXxd7hFaQzEpmjCkUioEDB4o9BQBAE+Ryebdu3XSvdwFoGwm8Ag0AAMAcYCUDAACQgJUMAABAAlYyAAAACVjJAAAAJGAlAwAAkICVDAAAQAJWMgAAAAlYyQAAACRgJQMAAJCAlQwAAEACVjIAAAAJWMkAAAAkYCUDAACQgJUMAABAAlYyAAAACQpBTvn1119nzZolyFF0JCQk+Pj4iD1Fq6EFHWhBB1rQgRbNEGAlv/DCC7m5ufn5+fyPIqVLly59+vQRe4rWQQs60IIOtKADLZon4ziO/ykAAADAE55LBgAAIAErGQAAgASsZAAAABL+P3TzYWD8a5N1AAAAAElFTkSuQmCC",
+                        "text/plain": [
+                            "<IPython.core.display.Image object>"
+                        ]
+                    },
+                    "execution_count": 18,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "r.visualize()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 19,
+            "id": "0f9ef296-e753-4fbb-939c-83e5052e28de",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "CPU times: user 11.3 ms, sys: 3.31 ms, total: 14.6 ms\n",
+                        "Wall time: 4.03 s\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "<style scoped>\n",
+                            "    .dataframe tbody tr th:only-of-type {\n",
+                            "        vertical-align: middle;\n",
+                            "    }\n",
+                            "\n",
+                            "    .dataframe tbody tr th {\n",
+                            "        vertical-align: top;\n",
+                            "    }\n",
+                            "\n",
+                            "    .dataframe thead th {\n",
+                            "        text-align: right;\n",
+                            "    }\n",
+                            "</style>\n",
+                            "<table border=\"1\" class=\"dataframe\">\n",
+                            "  <thead>\n",
+                            "    <tr style=\"text-align: right;\">\n",
+                            "      <th></th>\n",
+                            "      <th>a</th>\n",
+                            "      <th>b</th>\n",
+                            "    </tr>\n",
+                            "  </thead>\n",
+                            "  <tbody>\n",
+                            "    <tr>\n",
+                            "      <th>0</th>\n",
+                            "      <td>5</td>\n",
+                            "      <td>9</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>1</th>\n",
+                            "      <td>13</td>\n",
+                            "      <td>17</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>2</th>\n",
+                            "      <td>19</td>\n",
+                            "      <td>11</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>3</th>\n",
+                            "      <td>3</td>\n",
+                            "      <td>11</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>4</th>\n",
+                            "      <td>16</td>\n",
+                            "      <td>5</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>5</th>\n",
+                            "      <td>17</td>\n",
+                            "      <td>13</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>6</th>\n",
+                            "      <td>18</td>\n",
+                            "      <td>12</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>7</th>\n",
+                            "      <td>17</td>\n",
+                            "      <td>17</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>8</th>\n",
+                            "      <td>17</td>\n",
+                            "      <td>7</td>\n",
+                            "    </tr>\n",
+                            "    <tr>\n",
+                            "      <th>9</th>\n",
+                            "      <td>5</td>\n",
+                            "      <td>3</td>\n",
+                            "    </tr>\n",
+                            "  </tbody>\n",
+                            "</table>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "    a   b\n",
+                            "0   5   9\n",
+                            "1  13  17\n",
+                            "2  19  11\n",
+                            "3   3  11\n",
+                            "4  16   5\n",
+                            "5  17  13\n",
+                            "6  18  12\n",
+                            "7  17  17\n",
+                            "8  17   7\n",
+                            "9   5   3"
+                        ]
+                    },
+                    "execution_count": 19,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "%%time\n",
+                "s = ddf.applymap(inc, meta=ddf)\n",
+                "s.compute()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 20,
+            "id": "99022ba6-f6fa-42cb-a42d-0897d56069a6",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwUAAAFQCAIAAABh20VDAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdd0BT5/4/8OdkgkxZBWSKKKjgKA6gbirFWbV1e9W6aq16e22rt7ba26Ud+rWtttW6FTfW2opI3QouRFkOQAFBZcqeITm/P3IvP4oIgZycJ5y8X39JEp7nQx7PO58kZzAsyxIAAAAAAyaiXQAAAAAAZeiHAAAAwNChHwIAAABDJ+FtppiYmIcPH/I2HZ/s7e0HDhxIuwo6cnJyLly4QLsKXRk3bpxUKqVdBR3Hjh2rqamhXYVO9OnTx93dnXYVdCCHBQk5zA2WL3PnzuXj76EhKCiIt6dR35w6dYr2069DhYWFtJ9gaszNzWk//bqyZcsW2s8uNchhQUIOc4LX78sE+f9VwPmiOeH1DcLOFw0Jsm8QcJ+nIeSwUCGHtYT9hwAAAMDQoR8CAAAAQ4d+CAAAAAwd+iEAAAAwdOiHAAAAwNChHwIAAABDh34IAAAADB36IQAAADB06IcAAADA0KEfAgAAAEOHfggAAAAMHfohAAAAMHTohwAAAMDQCbYfUqlUtEsAAI2UlZXRLgG4V1tbq1QqaVcBOlFaWlpQUEC7Co4JrR9KTk5eunSpm5ubtbX1qFGjzpw5Q7si4JKnp+e8efNoVwHciI2NDQ4OtrKyMjMzs7e3X7BgQUlJCe2igAOhoaEBAQFmZmZGRkZeXl4bN27EG1QhKSgo8PLyGjBgAO1COCaofqiysnLMmDHbt28PDg5euHBhSkrK6NGjL168SLsu4MbOnTtTU1NpVwHciImJGTp06M2bN6dOnfrJJ59YWFhs2bIlKCgIL5xt3e7du2fMmFFYWLh06dJ33nmnrKxs8eLFX331Fe26gDNz5sx58uQJ7Sq4J6FdAJdWrlx5//798PDwkJAQQsjSpUt79Ogxa9ashw8f0i4NWi8rK+s///nPjRs34uLiaNcCnNm4cWNlZeW1a9d69uxJCPnss8+CgoLOnDkTFhb25ptv0q4OWm/dunWenp7Xrl0zNzcnhCxfvtzd3X3Tpk0ff/wx7dKAAz///HNERISVlRXtQrgnqM+Hdu7c6evrq26GCCEvvfRScHBwWlratWvX6BYG2igtLU1OTrawsOjTpw/tWoAz0dHRPXv2VDdDarNnzyaEXL9+nV5RoK3i4uLExMSQkBB1M0QIcXR0HDp06LNnzxQKBd3aQHtJSUnLli37+uuvHRwcaNfCPeF8PpSfn19YWKiO1DqdO3cmhMTExPTr149SXaAtb2/vCxcuEEJSU1M9PT1plwMcUCgUwcHBffv2rX9jZmYmIUSQ7zsNh0QiuXjxYseOHetuKS4ujo+PHz58uFQqpVgYaK+qqmrKlCkDBgxYsmTJr7/+Srsc7gmnH7p//z4hpEHT2qVLF0JIbm4unZoAoDFSqfTHH3+sf0tubu6mTZukUumoUaNoVQXaMzExCQwMVP97w4YNGRkZJ06cUCqV//73v+kWBtr74IMPnjx5curUKYZhaNeiE8Lph9R72jZ4c+nq6koIKSoqolMTAGjgzz//nDNnTl5e3oYNG3x8fGiXA9xYuXJlRUUFIaRbt27Gxsa0ywGt/Pnnnxs3bjx69KggvylTE87+Q3K5nBDy7Nmz+jeWl5cTQtq3b0+nJgBo0oMHD8aMGTN69Ghzc/PIyMglS5bQrgg4U15enpycvH379oKCgn79+mVnZ9OuCFrp6dOns2fPnjt37rhx42jXokPC+XzI3t6eENLgUDJ1e2Rra0unJgB4sb179y5cuJBhmG+++WbJkiXqtzTQprEsy7KsSPTfd9qenp6enp4ikWjWrFnh4eFvvfUW3fKgdX7++ef8/Pzi4uK6PXQfP37Msuzs2bM7d+4smC9DhdMPde7cmWGYBv2Q+ght7EwNoG/+/PPPf/zjH/7+/vv373dxcaFdDnBj7dq1H3300YkTJ0aMGFF3o42NDfnf/vLQFtna2vbs2TMlJaXulurqapVKdfv27breVwCE0w85OjoOHDjw4sWLDx488PDwIIQoFIp9+/Z16NDh5Zdfpl0dAPzNRx99ZGFhceTIEQHvjmCA1Lt//fXXX/X7IfWxSD169KBWFmhn8eLFixcvrn/Lyy+/XFlZeevWLVol6YJw+iFCyEcffTRy5MiJEyeuXLmyffv2X3/99cOHD//880+h7gwP0EYVFhYmJib26tVr3bp1De4aPHgwDjFru0aMGOHj4/Pjjz9aWloGBwc/fvz48OHDf/zxR58+fbCsoOcE1Q8NHz58z549c+fOnTBhAiHE0tJy/fr1dadnBAA9ERUVxbJsbGxsbGxsg7sYhsELZ9slEomOHTs2ffr0Tz/99NNPP1XfOH78+B9++EEiEdTLDQiP0P6DTp48+Y033oiJiVGpVP369ROLxbQrAs506tSJZVnaVQAHRo0ahaUUqo4dO16+fDktLe3evXvGxsZdunTp0KED7aKAYzdv3qRdAveE1g8RQiQSSf/+/WlXAQBgoEQikYeHh3o/ToC2Qjh7hgMAAAC0DvohAAAAMHTohwAAAMDQoR8CAAAAQ4d+CAAAAAwd+iEAAAAwdOiHAAAAwNChHwIAAABDh34IAAAADB36IQAAADB06IcAAADA0KEfAgAAAEOHfggAAAAMHfohAAAAMHTohwAAAMDQCbMfqq6uzs3NpV0FcC8rK4t2CcA9LKsgIYeFSqgbrITPyXJycg4dOsTDRDdu3MjLyxsxYgQPc6WlpTEMw8NE+uzYsWPt2rXT9SwKhWL9+vXLly/X9USEkPj4eB5m0XMxMTEWFhY8TLRx48YpU6ZYW1vzMJdCoeBhFn2GHBYq5LC2WL7MnTuX1z+MR0FBQbw9jfrm1KlTtJ9+HSosLKT9BFNjbm5O++nXlS1bttB+dqlBDgsScpgTDMuytP9YjpWXl9vY2FRVVSUnJ3t6etIuBzgzduzY48ePr127lp+3JsCP/fv3T5061dfXNy4ujnYtwBnksFAJOIcFuP/Qb7/9VlNTI5FI+PlMGPhRXFx88uRJQsiuXbto1wJcCg0NZRgmPj4+OTmZdi3AGeSwIAk7hwXYD+3Zs4dhmNra2h07dtCuBThz9OhRpVJJCLl7925SUhLtcoAbhYWFkZGRLMvKZLL9+/fTLgc4gxwWJGHnsND6ofz8/DNnzqgX7MGDB9grVjDU8UoIkclkBw4coF0OcOPIkSPqrbWmpgYvnIKBHBYqYeew0Pqhw4cP1/1bKpXiHacw5ObmXrhwoe6Fc+fOncLb780w7dmzp+7fGRkZsbGxFIsBriCHBUnwOSy0fmjPnj11K6RQKHbt2iWwBTNMBw4cEIn+///VrKys69evU6wHOPH06dOoqCiVSqX+EV+ZCQZyWJAEn8OC6ocyMzOvXr1aF6+EkKdPn0ZHR1MsCTixe/du9ZsSNbxwCsP+/fvrx2tNTc2uXbvqLzS0RchhoRJ8DguqH9q/f79YLK5/Cz6qFYCHDx/GxsbWf39ZU1Ozd+9evHC2dQ3ilRCSl5d3+fJlWvUAJ5DDgmQIOSyofuj5eFUoFKGhobW1tbRKAu3t379fIml4IvWCgoJz585RqQc48eDBg7i4uAZfo0il0n379tEqCTiBHBYkQ8hh4fRD9+7dS0pKev5b6qKiotOnT1MpCTixZ8+e56+xgBfOtm7v3r1SqbTBjQqFYv/+/TU1NVRKAu0hh4XKEHJYOP3Qvn37no9XIrgFMzTx8fH3799//naFQnHw4MGqqir+SwJO7N27t9FLiZWVlUVGRvJfD3ACOSxIBpLDwumHdu/e3Wi8KhSKI0eOVFZW8l8SaG///v2NxishpLKyMiIigud6gBOxsbGpqamN3iUWi0NDQ3muB7iCHBYkA8lhgfRDN27cyMjIkEgkcrlcLpfLZDKZTKb+t1QqraysPHHiBO0aocVYlg0NDVUqlfL/qVtWuVxOCME7zjZKfSa3+stat7Isyx4/fry8vJx2jdBiyGFBMpwcbrh7VBulUqnWrl1b9+PRo0cLCwvnzJlTd4uAL9YtYMXFxYsWLar7MSUlZdu2batXrzY2NlbfUvcPaFu6detWf4P99NNPR4wY0bdv37pbCgoKTExMaJQGrYccFiTDyWEBXt+eEDJ//vz09HTshSAwkZGRwcHBhYWFlpaWtGsBLllaWn777bfz5s2jXQhwCTksSALOYYF8XwYAAADQauiHAAAAwNChHwIAAABDh34IAAAADB36IQAAADB06IcAAADA0KEfAgAAAEOHfggAAAAMHfohAAAAMHTohwAAAMDQoR8CAAAAQ4d+CAAAAAwd+iEAAAAwdOiHAAAAwNChHwIAAABDh34IAAAADB36IQAAADB06IcAAADA0KEfAgAAAEOHfggAAAAMHfohAAAAMHTohwAAAMDQoR8CAAAAQ4d+CAAAAAwd+iEAAAAwdOiHAAAAwNChHwIAAABDh34IAAAADB36IQAAADB06IcAAADA0KEfAgAAAEMnoV0AB/Lz8wv+p6qqimXZe/fu5efnHzhwQCwWy2Qy6/+xsbERidACtg3l5eV5eXnqxS0pKSGEXLt2jRBy4MABa2trQkjdstra2srlcsrlgmYUCkVeXl7dBqtSqaqrq2tqai5fvmxpaUkIMTU1VS+rnZ2dmZkZ7XpBU8hhQTKoHGZYlqVdQwuUl5cnJSXFxcUlJCSkpqamp6enpaVVVVXVfwzDMBYWFoSQ0tJSpVJZ/y6ZTObq6urm5taxY8cePXr4+Pj4+PioHwwUKZXK1NTU+Pj4uLi4e/fupaenp6enFxQUNHiYqampRCKpqqp6fsUdHBzc3d3d3Ny6d+/u4+Pj6+vr7OzM3x8AL5CdnZ2QkHD79u07d+48ePAgPT39yZMnz2+V7dq1U6lU6rStz8LCws3Nzc3NzcvLy9fX19fXt0uXLlKplMe/ABqBHBYk5HAb6Idyc3PPnDkTHR0dFRUVHx+vVCpNTU27devWpUsX9VPv5ORkZ2enblGNjIwa/HpNTU1BQYG6vc3MzFSvcUpKSkJCQlFREcMwXbt2DQwMDAgIGDZsmJOTE40/0RBVV1dfvnz50qVL0dHRV69eLS0tFYvFnp6e3bp1Uy+rq6urnZ2djY2NjY2Nubn58yPUvR/Nzs5WL+uDBw+SkpIyMjIIIfb29gEBAYGBgQMHDuzduzfej/ImISHh/PnzV65cuXz5cmZmJiHEwcHBx8fHw8PDzc3N3d3dwcGhic8JysrKCgoK8vLycnNzHz16pF7Zu3fv3r17V6FQGBsb9+nT55VXXgkMDBw0aJCJiQmNP9EQIYcFCTlcn/72Qzdv3vz9999PnjwZGxsrFot79+7t7+8fEBDQu3dvd3d3Tp7WjIyMuLg49RYeExNTVVXl4+Pz2muvjRkzJiAgQM9Xro16+vTpsWPHwsPDz507V15e7uHhERAQEBAQ0KdPn27duj0fo61QVFQUHx9//fr1y5cvX7lyJTc3187OLjg4eOTIkSNHjjQ1NdV+Cmigqqrq1KlTJ06cOHnyZFZWVvv27f3/p0ePHjY2NtpPoVAo7t69e/PmzaioqOjo6Hv37slksoEDB4aEhIwbN87NzU37KeB5yGFBQg43jtUzSUlJH330UadOnQghbm5uCxcu/P3338vKynQ9b2Vl5alTp/75z3926dKFEOLk5PTee+/duHFD1/MaiGfPnv3000+DBw8WiURmZmbjxo3bvHnzo0ePeJg6Li5u7dq1gwcPlkgkxsbGb7zxxpEjR6qrq3mYWvBqa2tPnDgxY8YMc3NzkUjUv3//zz777Pr160qlUtdTZ2dn79y5c/LkyVZWVgzD9OvXb/369U+fPtX1vAYCOSxIyOGm6Us/VFFRsXPnzsDAQEKIq6vr+++/f/36dVrFJCYmfvLJJ+oNsmfPnps2bSoqKqJVTFt38eLFGTNmGBkZmZiYTJ48+ejRo5WVlVQqyc/P37Jly7Bhw8Risa2t7bJly+7du0elEgHIyMhYtWqVk5MTwzCBgYHff//948ePqVRSU1MTHh4+a9YsS0tLqVQ6fvz4kydP8tCQCRJyWKiQw5qg3w/l5OSsXr3axsZGJpO9+eabx48fr62tpV3Uf8XExMyfP9/U1NTU1HT+/Pn379+nXVGbUVNTc+jQoX79+hFCXn755Q0bNjx79ox2Uf/15MmTtWvXduzYkRASGBh4/PhxlUpFu6g24+bNmzNmzJBIJC+99NLy5ctTUlJoV/RfVVVVhw4dCgoKYhjGw8Njw4YN5eXltItqM5DDgoQcbhGa/VBmZubChQvlcrmtre3q1atzcnIoFtOEoqKi7777ztnZWSKRTJs2DVtj06qqqn788UcnJyepVDplyhS9/axbqVQeP3580KBBhJDevXsfP36cdkX67ty5cwMHDlQH6759+2pqamhX1Lg7d+7MmzfPyMjIxsbmq6++Ki0tpV2RXkMOCxJyuBXo9EM5OTlLliwxMjJydXX95ZdfaH1w1yI1NTV79+719vaWSCSzZ89OT0+nXZHeUSgUW7ZscXFxMTIyWrp0aUZGBu2KNHLjxo1x48YxDNO3b9/IyEja5eijK1euDB06lBASFBR0/vx52uVoJCcnZ+XKlWZmZnZ2duvWrVOfEQfqQw4LEnK41fjuh6qrq7/55htzc3NHR8eNGzfq2+5Uzaqtrd29e3enTp2MjY1XrlyJt551/vrrr+7du8tksoULF2ZlZdEup8ViYmJGjhxJCBk5cqT+fJ9N3aNHj6ZMmcIwzIABAy5cuEC7nBbLy8v78MMPTUxMOnbseOTIEdrl6AvksFAhh7XBaz8UGRmp/h/8ySef8HCogu7U1NSsW7fO0tLS0dHx4MGDtMuhLDMz8/XXXyeEjB49uq1/iH327FlfX1+pVLps2TID3/ukpqbm888/b9eunYeHx9GjR2mXo5WsrKzp06czDDN48GA0u8hhQUIOa4+nfqigoGDmzJmEkPHjx7eVj++alZubO2fOHIZhRo8enZmZSbscCpRK5aZNm8zNzT09PQXzTVNtbe3PP/9saWnZsWNHwfxRLXXt2jUfH5927dqtWbNGMN80XblypVevXkZGRl988YXe7vykU8hhQUIOc4WPfujEiRMvvfSSo6Pjb7/9xsN0PDt37pynp6e5ufnu3btp18KrR48eqU8msWLFioqKCtrlcOzJkycTJkwghMyfP79Nv4duqZqamn//+99isXjYsGGpqam0y+GYQqH4+uuvjY2Ne/XqdefOHdrl8Ao5LEjIYQ7pth+qqKh49913GYaZPn26gE8dUVFRsXTpUoZhpkyZIuA/s74DBw5YWlp6e3vHxsbSrkWHDh06ZGVl1aVLl5iYGNq18OH+/ft+fn4mJiabN2+mfuyr7iQnJ/fr18/Y2Pinn34S8J9ZBzksVMhhbumwH8rIyPDz8zM3N9+zZ4/uZtEff/31l6Ojo4uLC8UzmPGgqqpqyZIlhJAZM2YYwgcnT58+fe211yQSydq1a2nXolvHjh2zsLDw8/MzhD1sFArF6tWrxWLxmDFjhP3aiRwWJOSwLuiqHwoPD2/fvn2vXr0ePnyooyn0UE5OzuDBg42NjYX6mW1WVlb//v3NzMzCwsJo18IfpVK5evVqkUg0c+ZM4X0izbKsQqF4//33GYZZtGhRmzvUSBtnz561s7Pr2rWrUFtA5DDtWnQCOayjHNZJP7RhwwaRSDRt2jQDPEKntrZ2+fLlDMMsWbJEYBcNiIuLc3Jy6ty5c2JiIu1aKDhx4kT79u379u2bnZ1NuxYulZaWjhw50sjIaNu2bbRroaDupSU8PJx2LRxDDiOHhUenOcxxP1RbW7t48WKGYVavXs3tyG3LwYMHjYyMJkyYIJiPEyIiIszMzIKCgoT95ULTUlNTu3Tp4u7uLphdcR8/fty7d297e3thf7nQtKqqqunTp0skkl9++YV2LdxADqshhwVJdznMZT9UXV09YcIEY2Pjw4cPczhsG3X27Nn27dsPGjSopKSEdi3a2r59u1gsnjt3rmEepVxfbm6uv7+/lZWVABqI+/fvOzs7d+3aNS0tjXYtlKlUqo8++ohhmK+++op2LdpCDteHHBYkHeUwZ/1QZWXliBEjzM3NL168yNWYbV1CQoK9vX3fvn0LCgpo19J6mzZtYhjm448/pl2IvqioqFD/V2+L52uuo/7P2b9/f/25viN1GzduZBjmo48+ol1I6yGHn4ccFiRd5DA3/VBlZWVQUJAw3jRzKzk52cXFpUePHm10U9ywYYMw3jRzS/0WvF27dmfOnKFdS2vExcXZ2NgI400zt3bs2CEWi5ctW0a7kNZADr8IcliQOM9hDvqh6urqESNGWFlZ3bp1S/vRhCctLc3FxaVPnz7FxcW0a2mZX375hWGY7777jnYh+kihUEyaNMnU1DQ6Opp2LS1z9+5dOzu7IUOGGOButpoIDQ0Vi8WffPIJ7UJaBjncNOSwIHGbw9r2Q7W1tRMmTDA3N8c7kiYkJyc7ODgMGDCgDe3Wt2fPHpFI9Pnnn9MuRH/V1NSMGTPG0tKyDb0CPXz4sEOHDgEBAbgEZhO2bdvGMMw333xDuxBNIYc1gRwWJA5zWNt+6N133zU2NsZ31c1KTEy0srKaMGFCmzj48/Tp01Kp9MMPP6RdiL6rqqoaNmyYo6Pjo0ePaNfSvIKCAi8vr169ehnywSkaUn9DsW/fPtqFaAQ5rCHksCBxlcNa9UPr169nGCY0NFSbQQzHxYsX5XL5+++/T7uQZiQlJVlaWk6cONEQLmWgveLiYl9f365duxYWFtKupSk1NTXqyDDMa162wnvvvSeTyc6ePUu7kGYgh1sEOSxInORw6/uh8PBwkUjUhj5S1gd79+5lGEafT3yXn5/v5ub2yiuvCOaq5jzIyMhwcHAYOXKkPr/pfOutt8zNzePj42kX0mYolcpx48ZZW1unp6fTruWFkMOtgBwWJO1zuJX9UFpamrW19bRp01r364ZsxYoVRkZG+vk1v1KpDAkJcXZ2zs3NpV1LG3P16lW5XK63p7/7+eefGYYxqLP7c6KioqJXr149evTQz33PkcOthhwWJC1zuDX9UEVFRY8ePXr16tWG9krTH7W1ta+++qqrq2t+fj7tWhpauXKl3maE/vvpp59EItGJEydoF9LQtWvX5HJ5mztgSk+kpKRYWlq+9dZbtAtpCDmsDeSwUGmTw63ph959911LS0uDukAgt/Ly8pydncePH0+7kL85e/asSCTavHkz7ULasH/84x+2trZPnz6lXcj/V1JS4uHhERwcrM/f5em548ePMwyzf/9+2oX8DXJYS8hhoWp1Dre4H4qIiMC+e9q7ePGiWCz+9ddfaRfyX4WFhS4uLq+//jrtQtq2srKyzp07Dx8+XH92gZw1a5aNjc2TJ09oF9K2LVq0yMLCQn92JEIOcwI5LEitzuGW9UP5+fkvvfTS9OnTW/Rb0Kjly5ebmJg8ePCAdiEsy7JTpkxxdHTUw4+O25yrV69KJJIff/yRdiEsy7JHjx4lhPz++++0C2nzKioqunXrNnjwYH3odJHDHEIOC1Lrcrhl/dDMmTMdHR1x8hJOVFdXd+/ePSgoiHrC/vHHH4QQPdzxpY1auXKlmZlZRkYG3TIKCwsdHBxmzZpFtwzBiImJkUgk+vBFBnKYQ8hhoWpFDregHzpz5gzDMEePHm15YdC4a9euicXiHTt2UKyhpKTE2dl56tSpFGsQmKqqKm9v75CQELplzJ0718bGJi8vj24ZQvL++++bm5tnZWVRrAE5zDnksCC1Ioc17Yeqq6s7deo0YcKEVhUGL7RkyRIbGxuK1xhftmyZtbU1Duzk1oULF+ge3x4dHc0wzIEDB2gVIEjl5eUdO3acMmUKrQKQwzqCHBakluawpv3QN998Y2xsrD+7EwpGSUmJvb390qVLqcyempoql8t/+uknKrML27Rp09zd3SsrK/mfWqVS9e3bd8iQIfxPLXjHjh0jhNC6MgZyWEeQw0LVohzWqB/KycmxsLBYtWqVdoVB4zZv3iyVSu/evcv/1KNHj/bx8VEoFPxPLXiZmZkmJiZr1qzhf+rdu3eLxeLbt2/zP7UhCAoK8vPz4//8BchhnUIOC1KLclijfmjJkiWOjo5lZWXaFQaNq62t9fX15f8z8EuXLhFCIiMjeZ7XcHz66acWFhY8fwhfXV3t6uo6b948Pic1KPHx8SKRiP/vIpHDOoUcFirNc7j5fujx48fGxsabNm3iojBo3LFjxxiGiY2N5XPSIUOGvPLKK3zOaGhKS0ttbW1XrlzJ56QbN26Uy+VaXucZmjZ16tTOnTvz+YYeOcwD5LAgaZ7DzfdDb7/9tqurK64qp1MqlcrPz2/06NG8zXjmzBmKu0EYjrVr15qamvJ2kFdlZWWHDh2WLFnCz3QG6/79+xKJZM+ePbzNiBzmAXJYqDTM4Wb6oezsbLlc/ssvv3BXGDTujz/+YBgmISGBn+leffXVYcOG8TOXISsrK7OxseHtOq9btmyRy+U4GzUPZsyY0a1bN35OWoMc5g1yWJA0zOFm+qGPP/7Y1tYW1wvkgUql6tatGz9nz4uPj2cYJiIigoe5YNWqVVZWVjzs9qFSqby9vefMmaPriYBl2YSEBIZh+Dl7HnKYN8hhodIkh5vqhyoqKvh8awtbt26VyWSPHz/W9UQzZ87s3r079fOxGoicnBwjI6Off/5Z1xP9+eefDMMkJibqeiJQCw4O5uHNPXKYZ8hhQdIkh5vqh3bu3CmTyXJycrguDBpXVVVla2v7+eef63SWgoICIyOjLVu26HQWqO+tt97y9fXV9SwjR44cPny4rmeBOidPnmQY5t69ezqdBTnMM+SwUDWbwyLyYr/++uvrr79uZ2fXxGOAQ3K5fMaMGdu2bVOpVLqbZffu3RKJZPLkybqbAhqYN29efHz89evXdTdFVlZWRETE/PnzdTcFNDB8+HAXF5dt27bpdGmfWTsAACAASURBVBbkMM+Qw0LVbA6/sB+6c+dOVFTUvHnzdFMYNG7u3Lnp6emnT5/W3RRbt26dOnWqmZmZ7qaABvr37+/j47N161bdTbFt2zYbG5vRo0frbgpoQCQSvfXWW7t27aqpqdHRFMhhKpDDgtRsDr+wHwoNDXV1dR06dKhuCoPGeXt7+/v7h4aG6mj8W7duJSUlzZ49W0fjw4vMnj378OHD1dXVOhp/796906dPl8lkOhofGjVr1qy8vLzIyEgdjY8cpgI5LFRN5/AL+6FDhw5NnDhRJGrqCzXQhUmTJh07dqyqqkoXgx88eNDd3b1fv366GByaMGnSpJKSEh29cN68eTM1NRWfvfPPxcXF39//0KFDOhofOUwLcliQms7hxjezmJiY1NTUiRMn6rIwaNzEiRPLyspOnTqli8GPHDkyceJEhmF0MTg0wdHRMSAg4ODBg7oY/NChQ+7u7i+//LIuBoemqV84KysrOR8ZOUwRcliQms7hxvuh48ePu7m5IV6pcHBw8Pf3//333zkfOT4+/sGDB+PHj+d8ZNDEG2+8ceLEidraWs5H/v3339944w3EKxUTJkwoKys7f/485yMjhylCDgtVEznceD8UHh4eEhKCeKUlJCREfZIuboc9efKkra2tn58ft8OChkaMGFFUVHT16lVuh01LS7t///6IESO4HRY01KFDB19f34iICM5HRg7ThRwWpCZyuJF+KC8v79atWyEhIbovDBr32muvPX36ND4+ntthT548+dprr2FfBFo8PT09PDxOnjzJ7bDh4eFmZmYBAQHcDguaCwkJ4XxZkcPUIYcFqYkcbmRJzpw5IxaLhwwZovvCoHG9e/e2s7Pj9mjPysrKK1euBAcHczgmtFRwcDDnB/GeOXNm6NChOLKMouDg4JSUlIyMDA7HRA5ThxwWqhflcCP90OXLl3v37m1qaqr7qqBxDMMEBgZevnyZwzGvX79eU1MzYMAADseElhowYEBsbGxZWRmHY165cgXLSle/fv1kMllUVBSHYyKHqUMOC9WLcriRfigqKgqfvVOn3g45/Oo6KiqqQ4cOLi4uXA0IrTBgwIDa2tqYmBiuBkxJScnOzg4MDORqQGgFY2Pj3r17c9sPIYf1AXJYkF6Uww37ofLy8oSEBH9/f74Kg8YFBgbm5+c/ePCAqwGvXr2KV03q1FEYHR3N1YBXr141MjLq1asXVwNC6wQEBFy5coWr0ZDDegI5LEgvyuGG/VBCQoJSqezduzdfhUHjevToIRaL4+LiuBrw9u3beNXUB7169eJ2Wbt16yaXy7kaEFqnV69eSUlJXF24AzmsJ5DDQtVoDjfsh+Lj401MTNzd3fmqChpnbGzs4eGRkJDAyWhFRUVZWVm+vr6cjAba8PHx4WpZCSHx8fFYVn3g6+tbU1OTnJzMyWjIYT2BHBaqRnO4YT+UmJjo4+ODQwH1ga+vL1eHeiYkJLAs6+Pjw8looA0fH5/k5GSurgOQkJDQvXt3ToYCbXh5eUmlUq5eOJHD+gM5LEiN5nDD7S0lJaVLly48VgUv1Llz59TUVE6GSk5ONjY2dnJy4mQ00EaXLl2USmVaWpr2Q5WWlubk5GCD1QcymczNzS0lJYWT0ZDD+gM5LEiN5nDDfig9Pd3NzY2/orQWHh5+4MAB2lXohJubW3p6OidDZWRkuLu7t6ET3Qp4WdVfgnCysuqNuQ19qyLgZSWEuLu7c7XBIof1B3KYdhU60WgO/60fYln20aNHbWs7/Oabbz744APaVeiEu7t7aWlpfn6+9kOlp6e3oVdNIuhlNTc3b9++PSefD6k3ZldXV+2H4oeAl5Vw98KJHNYryGHaVehEozn8t37o2bNnFRUVzs7O/BYGjVOfoyIrK0v7obKysvAhrf5wcXHhZFkfP35sZWVlYmKi/VCgPRcXl8zMTO3HQQ7rFeSwUD2fw3/rh9QtsK2tLa9FwQvY2NgQQgoKCrQfKj8/387OTvtxgBO2trZYVuGxsbHhalkJclhvIIeF6vkcbqQfUi8/h86fP79o0aLOnTs7OztPmTLll19+USqVdfdOmjTpq6++io6OnjRpkq2tbbdu3b7++muVSqXJvfWtWrVqwIABDx8+rH/jzJkzg4ODa2tr582bN3PmzNTU1Llz5zo7Ow8dOnTv3r2EkPXr17/88st2dnYhISEN9oVsomzNq9KGpaWlWCzm5HPagoICa2tr7cdpoNVPkSEvKyHE2tqak3jVt2XV5AFqTS8rIaSlK6tNyHDFxsamqKhIXb82kMMalo0cVkMOt04jOczW88cffxBCKioqWO6cPXtWLBZbWVm9++67n376qfrUnB988EHdA6ytrT08PCwsLF5//fWPPvrIz8+PEDJnzhxN7mVZdtCgQU5OTizLhoaGEkLWrl1bd5f6u/xJkyaxLOvn52dvb+/o6Ni1a9cZM2bIZDKGYUJCQiQSyZgxY8aNGyeTyVxcXJRKpSZlN1sVV2xsbH766SftxzE2Nt61a5f249SnzVNk4Mv6zjvvDB48WPtxZsyYMXr0aO3HqU/Lp6jpB2i4rGwLV1bLkOHwqSOE5OXlaTkOcljfNljksCCX9fkc/ls/dOjQIYZhVCoVh1POmzdPLpcXFhaqf6ysrHRwcPDy8qp7gLpfXr9+vfpHpVI5ZMgQhmFiYmKavZett2BlZWWmpqZ+fn51I69bt44Q8scff7Asq35Ov/jiC/Vd4eHhhBBjY+P79++rb5k5cyYhpO7HpstutiquODs7183SaiqVimGYw4cPc1JSHW2eIgNf1mXLlvXv31/7cd58882JEydqP059Wj5FTT9Aw2VlW7iyWoYMV9TX68jMzNRyHOSwvm2wyGFBLuvzOfy3fmjv3r0ymYzbKe/evRsfH1/3Y3Fxsbe3t6OjY90t1tbWlpaW9Tf+v/76ixDy1VdfNXsvW2/BWJadMWMGISQtLU39Y//+/W1sbGpqaliW9fPzE4vF1dXV6rseP35MCBk5cmTdsDt27CCE/Pbbb5qU3WxVXPHw8FizZo2Wg1RXVxNCjh07xklJdbR5igx8Wf/973/36tVL+3HGjBkzffp07cepT8unqOkHaLisbAtXVsuQ4UpsbCwhJDU1VctxkMP6tsEih1khLuvzOfy3/Yeqq6tlMhnhlJeXl6Oj47p169544w0/Pz9nZ+e7d+82eIynp2f9UzJ069aNEFJ3Cb2m761v+vTphJAjR44QQjIzM69duzZp0iSpVKq+19HRse6vMzIyUt9S97tisZgQUnf5oWbL1rwqbcjlcvVWpA31CPyvLJb1RWQymfbLSgipqanRt2XV5AFqTS8racnKah8ynFBXy8kGixzWsGzkMHK41Z7PYZ2fD/7bb791cnL6/PPPFQpFUFDQzp07n7+6r4ODQ/0f1ccPq5/TZu+tb9iwYfb29uoFO3LkCMuy06ZNa/CL9TVxOvxmy9a8Km0wDMOyLFdDcTJOHS2fIkNeVpFIxNWyck77p0jD57DpZSUtWVntQ4YT6k1MFzt+ag85rA3kMBHisj6fw5L6P8hkMoVCweF8eXl5K1assLW1TUlJMTMzU9/45ZdfNnhYg7Ohq3fUqjtdfdP31icWiydPnvz9999nZmYePnzYw8PD399fR2VrXpU2qqurtb90ubpt5+rK22raP0VYVu3HkUql/G+wzT5FGj6HfC6r5lVpQ/1eU/vURg5rXnYb2mCRw1zVzJXnl/VvHZxMJuN2tTIyMlQq1fjx4+v+7MzMzNu3bzd4WHJycv2D8dTfNfbs2VOTextQ706xYcOGq1evqr/v1FHZLaqq1fR2O9T+KcKyaj+OXC7Xt2XV5AF1eFvWFlXVauq14GSDRQ5rWHYb2mCRw1zVzJVGlrX+zkTHjx8nhFRVVXG1v1JJSYmpqamVldXx48eTk5N37Njh5OTUvn17c3Pze/fuqR9jbW3NMEzXrl2PHj2amJj42WefiUSiuqNmmr6X/fsOX2peXl4ikYhhmIcPH9bd6OfnV/9gCvVZBxYsWFB3y+7duwkhBw8e1KTsZqviip2d3aZNm7QfRy6X79mzR/tx6mj5FBn4si5atGjQoEHajzN9+vQxY8ZoP04d7Z+iph+g4bKyLVlZ7UOGK+fPnyeE5OTkaDkOcljfNljkcB0hLevzOfy3fujSpUuEkCdPnnA45aFDh0xNTdW9l5WV1a5du44cOWJiYiKRSNQPsLa2DgoKmjlzZt3XjYMHD87Pz9fkXraxBfviiy8IIcOHD69/Y4sWrNmym62KEyqVSiKR7N+/X/uh7O3tv//+e+3HqU+bp8iQl5Vl2cmTJ48bN077cRYvXvzKK69oP059Wj5FTT9Aw2VlW7iyWoYMV8LCwhiGqTtErtWQw3q1wSKH608nmGVlG8vhv/VDd+7cIYTUPxCOE/n5+X/99VdiYmLdEXT5+fkpKSnqf1tbW7/22mssyz579iwyMjIpKan+7zZ9b6OOHj1KCAkLC9Nd2a2oqhWePXtGCImMjNR+qO7du69atUr7cRpo9VNkyMvKsuyrr746b9487cf59NNPvb29tR+nAW2eopY+hzwsayuqap3NmzdbWlpqPw5yWMOykcNqyOHWeT6H/9YP5eTkEELOnj2ro+kbVffHt+LeRo0cObJDhw4KhULr0l6oFVW1gvoLVE5OQjVo0KB33nlH+3E0h2VtQu/evZcvX679OBs3brS1tdV+HM01+xS19DnkYVlZvlZ2zZo1HTt21H4c5LCGkMPNwrI24fkc/tvxZTY2NnK5XH0ypbboyy+/fPz4cXh4+A8//CCRSJr/Bf2mvvQuJ9dDdnR05OT6zFQIbFkJIZmZmR06dNB+HAcHh/z8/KqqKs6PROUBlvVFkMN6BTmsJrBlJY1tsH/7q0QikbOzc1paGp81OTg4NHHlwqbvbWDLli1lZWVz586dP38+R9VxUFWrpaWlGRsbc3I9ZDc3txMnTmg/juawrC9SXl6el5fn5uam/VDu7u4sy2ZkZHB+JOqLNPsUaf4c8rasLapKG2lpae7u7tqPgxzWEHK4WVjWF2k0hxt2ee7u7hkZGboupb6EhIRW39sAb5W3qKpWS09Pd3Nz4+T8XW5ubjzHK5b1RdQLwckLp3pjTk9P560favYp0vw55DNneNtg+/Tpw8lQyGFNIIebhWV9kUZzuOEZJD08PJKTk3moBpqVkpLi4eHByVCdOnUqLS3Nzs7mZDTQRkpKikgk4qQfat++vbW1NTZYfVBbW5uWlsbVBosc1h/IYUFqNIcb9kM+Pj7q4xp4LAwaFxcX16NHD06G8vX1JYTEx8dzMhpoIz4+3sPD4/nT27eOj48PP2+noGnJyclVVVXqDU17yGH9gRwWpEZzuGE/5OvrW1xcnJmZyWNh0Ijq6uqUlBQfHx9ORrOxsXFwcMALpz5ISEjgalkJIb6+vohXfRAfHy+RSLy9vTkZDTmsJ5DDQtVoDjfy+ZBIJLp16xZfVUHjkpKSFAoFhy+cPXr0eP4M/cC/uLg4bvuhxMTE2tpargaE1omPj+/SpQsnl2EhyGG9gRwWqkZzuGE/ZGFh4e3tfeXKFb6qgsZFRUVZWlp6eXlxNWD//v2jo6O5Gg1aJycnJzU1NSAggKsB/f39y8vL8RERdZcvX27d5S0bhRzWE8hhQXpRDjfshwghgYGBUVFRvFQFLxQVFRUYGFh3wnLtBQYGPnz48OnTp1wNCK1w+fJlsVjcr18/rgb09va2srLCBktXTU3NzZs3AwMDORwTOawPkMOC9KIcbmSZAwICYmJiqqqqeCkMGhcVFcXhpwiEkH79+onFYiQsXVFRUT4+PhYWFlwNyDCMv7//5cuXuRoQWuHmzZsVFRXc9kPIYX2AHBakF+VwI/3QsGHDqqur1dcUBCqSkpKysrKCgoI4HNPMzKxPnz6RkZEcjgktderUqWHDhnE75tChQ0+fPq1UKrkdFjR36tQpZ2dnT09PDsdEDlOHHBaqF+VwI/2Qk5NTt27dTp48qfuqoHEnT560sbHx8/PjdtiQkJCTJ0/iIF5aMjMz79y589prr3E7bEhIyLNnz27cuMHtsKC5kydPjhgxgtsxkcPUIYcFqYkcbvxr0ZCQkPDwcB1XBS8UERExfPhwDr+0VgsJCcnKykpMTOR2WNDQyZMnTUxMBgwYwO2w3t7ebm5u2GBpyc/Pv3nzZnBwMOcjI4fpQg4LUhM53PhKjxkz5v79+0lJSTouDBqRn59/4cKF0aNHcz7yyy+/3KFDh7CwMM5HBk2EhYUNHz6cq0Oy6xs9ejSWlZbffvtNJpO9+uqrnI+MHKYIOSxUTeRw4/1QYGCgi4vLwYMHdVwYNCIsLEwmk40aNYrzkUUi0RtvvHHgwAHOR4Zm5efnnz17dvLkyboYfNKkSXfu3ME7TioOHjw4cuRIU1NTzkdGDlOEHBakpnO48X6IYZgJEyYcOnRIl4VB4w4fPqyjeCWETJw48f79+zhdDf/CwsLkcvnIkSN1Mbi/v7+TkxNeOPmXm5t74cKFiRMn6mJw5DBFyGFBajqHX/jN6NSpU+/fv48zR/EsIyPj3LlzU6dO1dH4/v7+HTt23Llzp47GhxfZuXPn2LFjubpsWQMikWjKlCm7d+9WqVS6GB9eZM+ePSYmJjpqcwlymBLksFA1ncMv7If8/Px69eq1detWnRUGjdi2bZutra3u4pVhmLfeemv37t04rwmfEhISrl69OnfuXN1NMXfu3MzMTBzHy7Pt27dPmzatXbt2OhofOUwFcliQms3hpvacnzt37sGDB4uLi3VQGDRCqVTu2LFj9uzZUqlUd7PMnj27uLj4t99+090U0MDWrVs7deo0ePBg3U3RuXPngQMHbtmyRXdTQAOXLl26c+fOnDlzdDoLcphnyGGhajaHm+qHpk2bJhaL8daEN2FhYU+fPp03b55OZ3F0dBw7duz333+v01mgTnFx8c6dOxcsWMAwjE4nevvtt48fP56WlqbTWaDO999/37dv3969e+t0FuQwz5DDgqRRDrNN+uc//+nk5FRTU9P0w4AT/fr1e/PNN3mYSH22+EuXLvEwF6xdu9bMzKyoqEjXE9XW1rq7uy9dulTXEwHLsg8ePBCLxYcOHeJhLuQwn5DDgqRJDjfTD6WlpUkkkr1793JaGDTi3LlzhJArV67wM52/v//YsWP5mcuQVVdXd+jQYdmyZfxMt27dOlNT02fPnvEznSF755133N3da2treZgLOcwb5LAgaZjDzfRDLMtOmzbNy8uLn83ekA0ZMmTw4MG8TXfs2DGGYW7dusXbjIZp06ZNcrk8MzOTn+lKSkqsra1XrlzJz3QG69GjR3K5/KeffuJtRuQwP5DDgqRhDjffDyUnJ0skkt27d3NUGDTizJkzhJDz58/zOWnfvn1Hjx7N54yGprKy0snJafHixXxOumbNGlNT05ycHD4nNTQLFixwcXGpqqribUbkMA+Qw4KkeQ433w+xLDtr1iwPD4/q6mqtC4NGqFSqgICAV199led5T5w4wecnwwZo/fr1xsbGT5484XPSsrIyOzs73r6hM0APHjyQyWRbtmzheV7ksE4hh4VK8xzWqB9KS0szMjJat26d1oVBIw4cOCASia5fv87/1AMHDvT391epVPxPLXj5+fnt27dfvnw5/1P/8MMPcrk8NTWV/6kNwYQJE7y8vPjfuxk5rFPIYUFqUQ5r1A+xLLty5Upzc/OnT59qURg0oqKiwtXVdfbs2VRmv3XrllgsDg0NpTK7sC1cuPCll14qLi7mf2qFQtG9e/fXX3+d/6kF7+zZs4SQ8PBwKrMjh3UEOSxULcphTfuh0tJSR0fHOXPmaFEYNGLVqlWmpqY8f6VS35w5c5ycnEpKSmgVIEi3bt2SSCTbt2+nVUBERAQh5NSpU7QKEKSamhpfX9+QkBBaBSCHdQQ5LEgtzWFN+yGWZQ8ePMgwzLlz51pTFzQmKSlJLpevX7+eYg25ubk2NjaLFi2iWIPA1NbW+vn5BQYGKpVKimVMmDDB3d29rKyMYg0C89VXXxkbGycnJ1OsATnMOeSwILUih1vQD7EsO3bsWE9Pz4qKipbXBg0plcpXXnmlT58+1I+h3bVrl0gkwmnBuPLdd9/JZLKkpCS6ZTx9+rR9+/bYsZorycnJxsbGa9eupV0IcphLyGGhakUOt6wfyszMtLCw+Oc//9nCwqAR3377rVQqvX37Nu1CWJZlX3vttc6dO+OzBO3duXOnXbt2//nPf2gXwrIsu3XrVrFYfPHiRdqFtHkKhcLf379Xr14KhYJ2LchhLiGHBal1Odyyfohl2d27dzMM8+eff7b0F6G+2NhYmUymD+811R4/fmxtbT1v3jzahbRtVVVVvXr18vPz059LK4wZM8bZ2RlnrNbSqlWrjIyM4uLiaBfyX8hhTiCHBanVOdzifohl2SlTpjg4OOCEb61WWlrq5eU1ZMgQuvuXNBAWFkYIOXLkCO1C2rD33nvPzMxMrw50z83Ntbe3nzx5Mu1C2rCLFy+KxeKNGzfSLuRvkMNaQg4LVatzuDX9UGFhYceOHQcPHqwPHx23RZMmTbK1teXtGg6aW7Bggbm5+b1792gX0iYdPnyYYZg9e/bQLqShyMhIkUj0ww8/0C6kTXr69KmDg8PYsWP17fQwyGEtIYcFSZscbk0/xLJsXFxcu3btsKtmK6xbt04kEkVERNAupBE1NTWBgYFdunShctacNu3evXvm5uZ6e3jI559/LpVKL1y4QLuQNkahUAwcONDT07OwsJB2LY1ADrcacliQtMzhVvZD7P++wN61a1erRzBAEREREolkzZo1tAt5oUePHtna2o4dO1avPkPWc/n5+Z6env7+/np7LQWVSjVmzBh7e/v09HTatbQlCxYsMDExiY+Pp13ICyGHWwE5LEja53Dr+yGWZT/88EOpVHr69GltBjEciYmJlpaWkydP1rcP3hu4dOmSkZERjl7RUHV19ZAhQzp06KCHH7zXV1JS0qNHD29vb+xbraGvv/5aJBKFhYXRLqQZyOEWQQ4LEic5rFU/pFQqJ06c2L59+4SEBG3GMQSPHj1ydnYePHiw3n6EUN+BAwcYhvm///s/2oXoO6VSOWnSJEtLy8TERNq1NC8zM7NDhw5Dhw7l88LsbZT6alZtYhNADmsOOSxIXOWwVv0Qy7KVlZWDBg2yt7ene85WPZednd2lS5fu3bu3obfm3377LcMwW7dupV2I/lKpVPPmzTMyMjp79iztWjR1+/ZtS0vLMWPG6M8ZAfTQn3/+KZVK33vvPdqFaAo5rAnksCBxmMPa9kMsy5aUlPTt29fFxSUtLU370YSnoKDA19fX09OzzV2FcdWqVWKxeN++fbQL0VPvvfeeVCo9fvw47UJaJjo62tTUdNKkSdRPyKufzpw5Y2RkNHfuXD3/PqUB5HDTkMNCxWEOc9APsSxbUFDQo0cPFxeXlJQUTgYUjOzsbF9fX1dX14yMDNq1tMa//vUvsViMvTUbUKlUixcvFovFBw4coF1La5w9e9bY2PjNN9/Ep0QNnDx5sl27dlOmTGmLzSJy+EWQw4LEeQ5z0w+xLFtYWNi/f/+XXnpJn4/F4NmTJ0+6devm7u7+4MED2rW03urVqxmG+f7772kXoi9qa2vnzJkjk8kOHz5Mu5bWu3jxorm5+YgRI3AZrDrHjx83MjKaNm1a2z2jD3L4echhQdJFDnPWD7EsW1ZWNnTo0Pbt2+PayyzLJiQkuLi4eHt7P378mHYt2lq7di0hZMmSJW3rGwRdKCsrGzt2rFwuP3bsGO1atBUTE2Ntbe3v75+bm0u7Fvp+/fVXiUTy9ttvt/UjnJHD9SGHBUlHOcxlP8SybFVV1eTJk2Uy2e7du7kduW3566+/LCwsAgMD8/LyaNfCje3bt0ul0okTJ1ZWVtKuhZqnT5/6+flZWVkJ5gqpSUlJbm5uHh4ehnwyXJVKpX7zvXr1atq1cAM5rIYcFiTd5TDH/RDLskqlctmyZQzDrFixoi1+B6+99evXSySS6dOnt4lDOjUXERFhbm4eGBgogHdarXDt2jVnZ2dPT0+B7ZyhDhdra+tTp07RroWCwsLCUaNGyeXy0NBQ2rVwCTmMHBYkneYw9/2Q2rZt24yMjF599VXBNOaaKC0tnTRpklgsXrNmjSA/0kxMTOzcubODg8OlS5do18KrzZs3y+Xy4ODggoIC2rVwr7y8fOrUqWKx+MsvvxTk/9sXiYuL69Spk6OjY1RUFO1adAI5LMj/z8hhHeWwrvohlmVjYmJcXV2dnZ3b0NlZtBEbG+vl5WVrayvsE8UWFRWNHTtWKpV++eWXhvC+s6ioaOrUqQzDfPLJJ219z5KmbdiwQSqVhoSEZGdn066FDz///HO7du0GDhwo7L8XOSxIyGFd0GE/xLJsfn7++PHjRSLRihUrBPahZX1KpfLbb7+VyWRDhgzR84s2cEKlUq1fv14ulw8cOLCNHr+qocuXL7u5udnb2588eZJ2LXyIjo7u2LGjnZ3dn3/+SbsWHcrNzR0zZoxYLP7444/b7qFkmkMOCxJymHO67YfUdu3aZWpq2r179ytXrvAwHc+Sk5OHDBkikUhWr15tCH16ncTERF9f33bt2q1du1Z4f3h5efny5cvFYvHw4cOfPHlCuxz+lJSUzJ8/nxDy5ptvCvK4s0OHDtnZ2bm4uFy4cIF2LbxCDgsScphDfPRDLMs+ePAgKChIJBItWbKkqKiIn0l1raKiYtWqVTKZrE+fPrdv36ZdDgWVlZUfffSRVCoNCAiIi4ujXQ5njh8/7urqamVltWPHDkHuf9CsY8eOdejQwdbWdvfu3YJ5BlJTU0NCQkQi0cKFCwWTQi2CHBYk5DBXeOqHWJZVqVQ7duywsbGxtbXdvHlzW+9kDx486Orqampqun79+rb+t2gpLi6uicxj9gAAFChJREFUb9++YrH47bffbuu7bSYlJQ0fPpwQMmXKFGHvVtKsoqKihQsXikSi/v37X7t2jXY5WikpKVm+fLlcLu/atauh7YLaAHJYqJDD2uOvH1J79uzZ0qVLpVKpj4/PsWPH2uJbz7NnzwYEBIhEolmzZhnUNylNUCqVO3fudHBwsLS0/OKLL0pLS2lX1GKPHj1asGCBRCLp1auXoX2T0oTY2NiBAwcyDDNlypS2eI6iqqqqH374wd7e3srK6vvvv8f1SdSQw4KEHNYS3/2Q2t27d8ePH88wjJ+f3x9//NFWtsZz584NGTKEEPLqq6/euHGDdjl6p7S0dNWqVebm5jY2Nt98801JSQntijTy6NGjd999Vy6Xu7m5bd++XdgHkbXO4cOHvb29xWLxzJkz79+/T7scjVRWVv70009OTk7Gxsbvvfdefn4+7Yr0DnJYkJDDrUanH1KLjY0dPXo0wzBdu3bdunVrVVUVxWKaUFtbe/DgwT59+hBCBg8eLJhzE+tIfn7+ihUrTE1NLSwsPvzww6ysLNoVvdCtW7emT58ulUqdnZ1/+uknAR96o73a2to9e/Z4enqKRKKxY8fq87dO+fn5n332mZ2dnVwuX7RokWGetk5zyGFBQg63As1+SC05OXnJkiVGRkaWlpbz58/Xq93BsrKy1q5d6+bmJhKJRo0aJdSTtulCcXHxhg0bnJycxGJxUFDQoUOH9OfA5srKykOHDgUFBTEM4+vru3nzZkM++X2LKJXK48ePBwYGEkK6du26du1avfrcJSYmZv78+SYmJubm5kuWLNHn1wB9gxwWJORwi9Dvh9SePHny+eefu7m5EUICAgI2bNhAMcvy8vI2b948dOhQkUhkb2+/YsWKNn1hZIqqq6v37t07ePBghmGcnZ3ff//969ev0yqmpqYmPDx85syZ5ubmcrl80qRJp0+fbivfEeibK1euzJ4928TExNjYeNKkSWFhYRUVFbSKiY+P//jjjz09PQkhffr02bx5c1lZGa1i2jTksCAhhzWkL/2QmlKpjIyM/Mc//mFhYSESiQIDA7/88subN2/y82QlJiZ+9913w4YNk0gk7dq1e/PNN3/77TfsgMmJ5OTklStXdurUiRDi7u7+7rvvnjhxory8nIepc3Nz9+7dO23aNCsrK4Zh+vfvv2HDhrZ+/IWeKC4u3rJly5AhQ8RisZmZ2RtvvLF161Z+vp+qqqo6ffr0+++/7+XlRQhxdnb+17/+ZZiHW3MOOSxUyOGmMSzLEv1TXV0dERHx+++/R0REPH361M7OLjAw8JVXXgkICOjRo4exsXGzI6hUKpFI1PRjampqEhMTo6Ojo6KiLl269PjxYxsbm1dffXXMmDGjR482MTHh6K+B/y82NvbIkSMRERG3b9+Wy+V9+/YNDAwMDAzs06ePnZ1ds7+uybISQtLS0q5evRodHX358uX4+HiJRPLKK6+MGDHijTfecHV15eLvgL/Jzs4OCws7ceLE+fPnKysru3btqt5g+/fv36lTp2aXTMNlLSwsjImJiYqKioqKunLlSnl5ube3d0hIyPjx4wMCAhiG4eivgf9CDgsVcrhRetoP1WFZNi4u7syZM5cvX46Ojs7NzRWLxR4eHr6+vp07d3Z3d3dzc3N2draxsbG2tq77rTt37jx8+HDUqFF1txQXF+fm5j5+/Dg9PT0tLS05OTkhISE5OVmhUFhaWgYEBAQGBg4bNqxPnz6aLDNoLzs7OzIy8tKlS1FRUeoDuV966SUfH5+uXbt27NhRvbK2trbW1tYymazut7755psPP/yw7sfKysr8/Pzs7Oy0tLT09PQHDx4kJiYmJiaWlJRIpdLevXsHBAQMGjRo2LBhpqamFP5Iw1NZWXnx4sXz589fvnw5JiamqqqqXbt23bp18/X1rVvWDh06WFtb13+dW79+/aJFi+RyufrH2tragoKCgoKCtLQ09creuXMnISEhKyuLEOLh4aF+VR4+fLh+pqrwIIeFCjlcn773Qw2kpqbevn07ISEhMTExOTk5PT29rKxMfZdIJGrfvr2FhQUhpKSkpLa21srKihBSWlpaWFhYW1urfpiRkZG7u3unTp26d+/u6+vr6+vr5eWFbY+ugoKCW7duxcfHJyQk3L17Nz09PScnp+5ec3NzS0tLiUSiUCiePHni4uLCMExVVVVRUVFFRYX6MWKxuEOHDh07dvT29u7Ro4ePj0/Pnj3btWtH6Q8CQgiprq5OSEiIi4tTb7APHz7MyspSKBTqe9W77qrX6PHjx9bW1kZGRiqVqqioqKioqG4Qa2trd3f3Ll26+Pj49OjRo2fPnvb29nT+Hvgf5LAgIYfbWD/0vLy8vMePHxcUFOTl5ZWUlBQWFrIsu2bNmrqTuFtYWJibm1tbW9va2jo6OiJM24TKysq0tLSC/ykpKVHvhXfx4sVp06b5+Pi0a9dOvazW1tbqy1FJpVLaVUMzlEplVlZWdna2elmLi4vLy8uzsrI2btzYrVu3GTNmSCSSumW1trZ2dXU1MzOjXTU0DzksSIaWw22+H3re1atX/f39GYbZt2/f5MmTaZcD3GBZ1tHRMTs7e+zYsceOHaNdDnDmX//61//93//J5fL8/Hw9/zgdNIccFiRh57AAP5/ct2+fTCYTiUR79+6lXQtw5tKlS9nZ2YSQ8PDw+t+nQJumUqnU26lCoRBevBoy5LAgCTuHhdYPKZXK0NDQmpoapVIZERFRUFBAuyLgxv79+9U79KlUqt9++412OcCN8+fP5+XlEUIYhsELp2Agh4VK2DkstH7ozJkzz549q/vx6NGjFIsBrqhP1V9TU6P+cc+ePXTrAa7s27dPvcOBUqk8ffp0bm4u7YqAA8hhQRJ8DgutH1J/SKv+N8uyu3fvplsPcOLUqVOFhYXqfyuVygsXLqg/s4U2raamRn0BAfWPDMOEhYXRLQk4gRwWJMHnsKD6oaqqqiNHjtR1ryqVKioq6vHjx3SrAu3VfYqgJhKJDh8+TLEe4MTJkyfrjtMmhKhUKrxwCgByWKgEn8OC6odOnDhRdyIENYlEcujQIVr1ACcqKip+++23uk8RCCFKpRIvnAIQGhoqkUjqflSpVNeuXUtPT6dXEXAAOSxIhpDDguqHQkNDxWJx/Vtqa2t37dpFqx7gxB9//FFVVVX/FpZlY2JiUlNTaZUE2isvL//jjz/qxyshRCKRCOwdpwFCDguSIeSwcPqhkpKSEydO1J3/VE19mvnk5GRaVYH2no9XQohUKsU7zjbt2LFjdV+p1FEoFHjhbNOQw0JlCDksnH7o6NGjDTZCNZlMduDAAf7rAU4UFhZGREQ8v7IKhWLHjh1USgJO7N27t9HrMyQlJSUlJfFfD3ACOSxIBpLDwumH9uzZ0+gFrmtqavCOs+0KCwtTqVSN3pWampqQkMBzPcCJZ8+enT59utEXTqlUevDgQf5LAk4ghwXJQHJYIP1Qbm7uhQsXlEplo/c+fPjw1q1bPJcEnNi7d++LtkOGYfbv389zPcCJw4cPN9oMEXxl1pYhh4XKQHJY0vxD2oKzZ8926NChbjusqKhQqVR110ISiUTnzp3r1asXvQKhNQoLC7OyshwdHdU/1tbWlpWVWVhY1L0BvXr1Kr3qoPWio6OdnJzqLp5YXFxsbGxcd8YahmHu3r3r7e1Nr0BoDeSwIBlODgvweq6EkPnz56enp0dGRtIuBLgUGRkZHBxcWFhoaWlJuxbgkqWl5bfffjtv3jzahQCXkMOCJOAcFsj3ZQAAAACthn4IAAAADB36IQAAADB06IcAAADA0KEfAgAAAEOHfggAAAAMHfohAAAAMHTohwAAAMDQoR8CAAAAQ4d+CAAAAAwd+iEAAAAwdOiHAAAAwNChHwIAAABDh34IAAAADB36IQAAADB06IcAAADA0KEfAgAAAEOHfggAAAAMHfohAAAAMHTohwAAAMDQoR8CAAAAQ4d+CAAAAAwd+iEAAAAwdOiHAAAAwNChHwIAAABDh34IAAAADB36IQAAADB06IcAAADA0KEfAgAAAEOHfggAAAAMHfohAAAAMHTohwAAAMDQMSzL8jPTihUr9u/fz89c1dXVKpXK2NiYn+kGDBiwd+9efubSN5cuXZo+fTo/cymVysrKShMTE4Zh+JkxISHB3Nycn7n0jY+PT0lJCT9zlZeXy2QyqVTKz3Rff/315MmT+ZlL3yCHBQk5zAkJD3OoFRQUyOXyefPm8TYjP44cOZKTk0O7CmoqKysfPXr02WefGRkZ0a6FS8nJyVu3blWpVLQLoebRo0fDhw/v27cv7UI4tmrVqtLSUtpVUIMcFiTkMCf464cIIa6urh988AGfM/IgOTk5PT2ddhWULV682NLSknYVXIqMjNy6dSvtKigbPny48F44v/jiC9olUIYcFirksJaw/xAAAAAYOvRDAAAAYOjQDwEAAIChQz8EAAAAhg79EAAAABg69EMAAABg6NAPAQAAgKFDPwQAAACGDv0QAAAAGDr0QwAAAGDo0A8BAACAoUM/BAAAAIYO/RAAAAAYOsH2QyqVinYJAKCRsrIy2iUA92pra5VKJe0qQCdKS0sLCgpoV8ExofVDycnJS5cudXNzs7a2HjVq1JkzZ2hXBFzy9PScN28e7SqAG7GxscHBwVZWVmZmZvb29gsWLCgpKaFdFHAgNDQ0ICDAzMzMyMjIy8tr48aNeIMqJAUFBV5eXgMGDKBdCMcE1Q9VVlaOGTNm+/btwcHBCxcuTElJGT169MWLF2nXBdzYuXNnamoq7SqAGzExMUOHDr158+bUqVM/+eQTCwuLLVu2BAUF4YWzrdu9e/eMGTMKCwuXLl36zjvvlJWVLV68+KuvvqJdF3Bmzpw5T548oV0F9yS0C+DSypUr79+/Hx4eHhISQghZunRpjx49Zs2a9fDhQ9qlQetlZWX95z//uXHjRlxcHO1agDMbN26srKy8du1az549CSGfffZZUFDQmTNnwsLC3nzzTdrVQeutW7fO09Pz2rVr5ubmhJDly5e7u7tv2rTp448/pl0acODnn3+OiIiwsrKiXQj3BPX50M6dO319fdXNECHkpZdeCg4OTktLu3btGt3CQBulpaXJyckWFhZ9+vShXQtwJjo6umfPnupmSG327NmEkOvXr9MrCrRVXFycmJgYEhKiboYIIY6OjkOHDn327JlCoaBbG2gvKSlp2bJlX3/9tYODA+1auCecz4fy8/MLCwvVkVqnc+fOhJCYmJh+/fpRqgu05e3tfeHCBUJIamqqp6cn7XKAAwqFIjg4uG/fvvVvzMzMJIQI8n2n4ZBIJBcvXuzYsWPdLcXFxfHx8cOHD5dKpRQLA+1VVVVNmTJlwIABS5Ys+fXXX2mXwz3h9EP3798nhDRoWrt06UIIyc3NpVMTADRGKpX++OOP9W/Jzc3dtGmTVPr/2rmXUIjaOI7jzxnzpkm5FCUKGcZCbk0aUrKixqVcs5DcNhZmpxgbxQJFQtnZEAuSMhR2Yue2sBAhC5dyT26J8y7mfeVV79sbYx5zzvezmp6zOL860zm/M+d/5o+CggJZqfB9AQEBWVlZ7s/9/f1HR0dzc3Ovr6+tra1yg+H7mpubT05OFhYWFEWRneVHaKcPuSdtP91cRkdHCyFubm7kZALwP7hcrvr6+vPz8/7+/qSkJNlx4BltbW0PDw9CiMTERJPJJDsOvsXlcg0NDU1PT2vySZmbduaH/P39hRBXV1cfF+/v74UQISEhcjIB+E/7+/tFRUWFhYWBgYGLi4sOh0N2InjM/f397u7uyMjI5eWlzWY7OzuTnQhfdHp6Wltb29DQUFxcLDvLD9LO70Ph4eFCiE+vkrnrUVhYmJxMAP7d2NhYY2Ojoig9PT0Oh8N9SwOfpqqqqqoGw1932vHx8fHx8QaDoaamZn5+vq6uTm48fM3w8PDFxcXt7e37hO7x8bGqqrW1tRaLRTMPQ7XThywWi6Ion/qQ+w1thqmB38blclVXV2dmZk5MTERFRcmOA8/o6upyOp1zc3N2u/19MTQ0VPw9Lw9fFBYWlpqaure3977y/Pz89va2tbX13n01QDt9KCIiIjs7e3l5eX9/32w2CyFeXl7Gx8cjIyOtVqvsdAD+wel0BgUFTU1NaXgcQYfc419LS0sf+5D7XaSUlBRpsfA9TU1NTU1NH1esVuvj4+Pm5qasSD9BO31ICOF0OvPz8ysqKtra2kJCQrq7uw8ODlwul1aH4QEfdX19vb29nZaW1tvb+2lTTk4Or5j5LrvdnpSUNDg4GBwcnJeXd3x8PDk5OTs7m56ezmHFL6epPpSbmzs6OtrQ0FBaWiqECA4O7uvre/97RgC/xOrqqqqqGxsbGxsbnzYpisKF03cZDIaZmZmqqqr29vb29nb3YklJycDAgNGoqcsNtEdrX9DKysqysrK1tbW3tzebzebn5yc7ETwmLi5OVVXZKeABBQUFHEqtio2NXVlZOTw83NnZMZlMCQkJkZGRskPBw9bX12VH8Dyt9SEhhNFozMjIkJ0CAHTKYDCYzWb3HCfgK7QzGQ4AAPA19CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB39CEAAKB3Rm/ubGVlJTo62pt79IKrq6uMjAzZKSRLTk5WFEV2Ck96enqSHUG+lpaWzs5O2Sk87O7uTnYEyTgPaxXn4W/yXh8qLy+3WCxe2503xcTEyI4gTUJCQk9Pj+wUP8VkMsmOIE1HR8fz87PsFD/CZrPJjiAN52FN4jzsEYqqqt7ZEwAAwO/E/BAAANA7+hAAANA7+hAAANC7PwEAlPrqcW8vqgAAAABJRU5ErkJggg==",
+                        "text/plain": [
+                            "<IPython.core.display.Image object>"
+                        ]
+                    },
+                    "execution_count": 20,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "s.visualize()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "8fe02d48-4d54-4fab-9dde-9ffad621f092",
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.9.0"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+}


### PR DESCRIPTION
Looks like the notebook corresponding to https://coiled.io/blog/parallelize-pandas-apply-and-map-with-dask-dataframe/ got deleted during the [repo-reorganization](https://github.com/coiled/coiled-resources/commit/d7b5e8e23efb09ace1962038f76129857929f65a#diff-05d6d634798ae610330ed3276158212480ad4f82e6153ac08ad58f3d174cd370). I've added it back with a better filename as per #20.

cc @MrPowers @LilyMelnyk 