### PR TITLE
don't specify senv in airflow examples

### DIFF
--- a/airflow-with-coiled/airflow-coiled-basic.py
+++ b/airflow-with-coiled/airflow-coiled-basic.py
@@ -46,7 +46,6 @@ def airflow_on_coiled():
         cluster = coiled.Cluster(
             n_workers=20, 
             name="airflow-task",
-            software="coiled-examples/airflow",
             backend_options={'spot': True},
         )
         client = Client(cluster)

--- a/airflow-with-coiled/airflow-coiled-json-parquet.py
+++ b/airflow-with-coiled/airflow-coiled-json-parquet.py
@@ -67,7 +67,6 @@ def json_to_parquet():
         cluster = coiled.Cluster(
             n_workers=20, 
             name="airflow-json",
-            software="coiled-examples/airflow",
             backend_options={'spot': True},
         )
         client = Client(cluster)


### PR DESCRIPTION
Completely untested but this has some chance of working (user would make environment locally from env file in the repo, and then use package sync) whereas what's here now has now chance of working (it's been over a year since you could specify a software environment in a different account).